### PR TITLE
Enable Content Security Policy

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: https://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

- Replaces `"csp": null` with an explicit restrictive policy in `tauri.conf.json`
- Policy: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: https://ipc.localhost`

## What's allowed

| Directive | Value | Why |
|-----------|-------|-----|
| `default-src` | `'self'` | Only load resources from the app origin |
| `script-src` | `'self'` | No inline scripts, no eval — only bundled JS |
| `style-src` | `'self' 'unsafe-inline'` | Svelte uses inline `style=` attributes |
| `img-src` | `'self' data:` | App icons + data URIs |
| `connect-src` | `ipc: https://ipc.localhost` | Tauri IPC bridge |

## What's blocked

- `eval()` and inline `<script>` tags (XSS via malicious device names, etc.)
- External network requests (`fetch`, `XMLHttpRequest` to remote hosts)
- Loading external scripts, stylesheets, fonts, or frames

## Test plan

- [x] Frontend builds successfully
- [x] `cargo check` parses the config without errors
- [ ] Manual: verify app loads and ECharts renders correctly
- [ ] Manual: verify Tauri commands (device scan, session start/stop) still work

Closes #2