### PR TITLE
Fix CSP to allow SvelteKit bootstrap and Google Fonts

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: https://ipc.localhost"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src ipc: https://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Problem

PR #32 enabled CSP with `script-src 'self'`, which blocked SvelteKit's inline bootstrap `<script>` in `index.html`, causing a blank window on launch. It also blocked Google Fonts loading from `fonts.googleapis.com`.

## Changes

Updated CSP directives:

| Directive | Before | After | Why |
|-----------|--------|-------|-----|
| `script-src` | `'self'` | `'self' 'unsafe-inline'` | SvelteKit emits an inline bootstrap script |
| `font-src` | (not set) | `'self' https://fonts.gstatic.com` | Google Fonts serves .woff2 from gstatic |
| `style-src-elem` | (not set) | `'self' 'unsafe-inline' https://fonts.googleapis.com` | Google Fonts CSS loaded via `<link>` |

## What's still blocked

- `eval()`, `new Function()`
- External script loading
- External network requests (fetch/XHR to remote hosts)
- Frames, objects, media from non-self origins

## Test plan

- [x] `cargo check` passes
- [x] Frontend builds
- [ ] Manual: verify app window renders content (not blank)
- [ ] Manual: verify fonts load correctly
- [ ] Manual: verify ECharts renders