### PR TITLE
Fix AppImage EGL crash on AMD/Mesa systems

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,16 @@ fn file_format(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Work around WebKitGTK EGL crashes in AppImage bundles on certain
+    // GPU/driver combinations (AMD Mesa, some NVIDIA). Must be set before
+    // WebKitGTK initializes. See: https://github.com/tauri-apps/tauri/issues/11988
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     tauri::Builder::default()
         .setup(|app| {
             let data_dir = app


### PR DESCRIPTION
## Problem

The AppImage crashes on launch with:
```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

This is a known upstream WebKitGTK issue ([tauri-apps/tauri#11988](https://github.com/tauri-apps/tauri/issues/11988)) where the bundled EGL/Mesa libraries in AppImages conflict with the system GPU drivers. Affects AMD Mesa and some NVIDIA configurations. The `.deb`, `.rpm`, and direct binary all work because they use the system WebKitGTK.

Setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` from the shell doesn't help because the AppImage's bundled WebKitGTK can crash before checking environment variables in some configurations.

## Fix

Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` in Rust code at the top of `run()`, before `tauri::Builder` and thus before WebKitGTK initializes. This is the same approach used by GitButler and other Tauri apps.

- Only applies on Linux (`#[cfg(target_os = "linux")]`)
- Respects the env var if already set by the user
- Disables DMA-BUF rendering (falls back to shared memory) — negligible visual impact

## Test plan

- [x] 164 tests pass
- [ ] Manual: download AppImage from release, verify it launches on AMD/Fedora
- [ ] Manual: verify charts and UI still render correctly