### PR TITLE
Tighten CSP: remove unsafe-inline from script-src

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src ipc: https://ipc.localhost"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src ipc: https://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- Removes `'unsafe-inline'` from `script-src` CSP directive
- The blank AppImage window was caused by an EGL crash (fixed in #34), not CSP blocking inline scripts
- Restores proper strict CSP: `script-src 'self'`

## Test plan
- [x] `npm run tauri dev` — app renders correctly with tightened CSP
- [ ] AppImage build renders correctly

Closes #2