### PR TITLE
Derive release artifact versions from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
           restore-keys: |
             node-${{ runner.os }}-
 
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          # Patch tauri.conf.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
+          # Patch Cargo.toml (only the package version, not dependency versions)
+          sed -i "0,/^version = \".*\"/s//version = \"$VERSION\"/" src-tauri/Cargo.toml
+          # Patch package.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
+          echo "Set version to $VERSION"
+
       - name: Install npm dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary
- Adds a "Set version from tag" step to the release workflow
- Strips the `v` prefix from the tag and patches `tauri.conf.json`, `Cargo.toml`, and `package.json` before building
- Artifacts will now be named `training-app_<version>` matching the release tag

## Test plan
- [ ] Push a tag like `v0.2.0` and verify artifacts are named `training-app_0.2.0_*`