### PR TITLE
Replace fragile serde_json enum serialization with as_str()

### DIFF
--- a/src-tauri/src/device/types.rs
+++ b/src-tauri/src/device/types.rs
@@ -7,12 +7,32 @@ pub enum Transport {
     AntPlus,
 }
 
+impl Transport {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ble => "Ble",
+            Self::AntPlus => "AntPlus",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum DeviceType {
     HeartRate,
     Power,
     CadenceSpeed,
     FitnessTrainer,
+}
+
+impl DeviceType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::HeartRate => "HeartRate",
+            Self::Power => "Power",
+            Self::CadenceSpeed => "CadenceSpeed",
+            Self::FitnessTrainer => "FitnessTrainer",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src-tauri/src/session/storage.rs
+++ b/src-tauri/src/session/storage.rs
@@ -226,14 +226,8 @@ impl Storage {
     }
 
     pub async fn upsert_known_device(&self, device: &DeviceInfo) -> Result<(), AppError> {
-        let device_type = serde_json::to_string(&device.device_type)
-            .unwrap()
-            .trim_matches('"')
-            .to_string();
-        let transport = serde_json::to_string(&device.transport)
-            .unwrap()
-            .trim_matches('"')
-            .to_string();
+        let device_type = device.device_type.as_str();
+        let transport = device.transport.as_str();
         let last_seen = device
             .last_seen
             .clone()


### PR DESCRIPTION
## Summary
- Add `as_str()` methods to `DeviceType` and `Transport` enums
- Replace `serde_json::to_string().unwrap().trim_matches('"')` with direct `as_str()` calls in `upsert_known_device`
- Eliminates latent panic from `.unwrap()` and fragile string manipulation
- Consistent with the `match`-based deserialization already on the read side

## Test plan
- [x] `cargo test` — 164 passed
- [x] Enum string values match existing DB format (HeartRate, Power, CadenceSpeed, FitnessTrainer, Ble, AntPlus)

Closes #10