### PR TITLE
Extract duplicated format helpers to shared module

### DIFF
--- a/src/lib/components/ActivityModal.svelte
+++ b/src/lib/components/ActivityModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import type { SessionSummary } from '$lib/tauri';
+  import { formatDuration, formatDate, autoTitle } from '$lib/utils/format';
 
   const ACTIVITY_TYPES = [
     { value: 'endurance', label: 'Endurance' },
@@ -44,27 +45,6 @@
   function handleClose() {
     dialogEl?.close();
     onClose();
-  }
-
-  function autoTitle(startTime: string): string {
-    const hour = new Date(startTime).getHours();
-    if (hour >= 5 && hour < 12) return 'Morning Ride';
-    if (hour >= 12 && hour < 17) return 'Afternoon Ride';
-    if (hour >= 17 && hour < 21) return 'Evening Ride';
-    return 'Night Ride';
-  }
-
-  function formatDuration(secs: number): string {
-    const h = Math.floor(secs / 3600);
-    const m = Math.floor((secs % 3600) / 60);
-    const s = secs % 60;
-    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-    return `${m}:${String(s).padStart(2, '0')}`;
-  }
-
-  function formatDate(iso: string): string {
-    const d = new Date(iso);
-    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
   }
 
   // Modal is freshly mounted each time — snapshot initial values (one-time read)

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,35 @@
+export function formatDuration(secs: number): string {
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export function autoTitle(startTime: string): string {
+  const hour = new Date(startTime).getHours();
+  if (hour >= 5 && hour < 12) return 'Morning Ride';
+  if (hour >= 12 && hour < 17) return 'Afternoon Ride';
+  if (hour >= 17 && hour < 21) return 'Evening Ride';
+  return 'Night Ride';
+}
+
+export function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+export function formatDateLong(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function formatDateShort(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import { trainerError } from '$lib/stores/trainer';
   import { api, extractError, type SessionSummary } from '$lib/tauri';
   import ActivityModal from '$lib/components/ActivityModal.svelte';
+  import { formatDuration } from '$lib/utils/format';
 
   let error = $state('');
   let postRideSession = $state<SessionSummary | null>(null);
@@ -51,14 +52,6 @@
     } catch (e) {
       error = extractError(e);
     }
-  }
-
-  function formatTime(secs: number): string {
-    const h = Math.floor(secs / 3600);
-    const m = Math.floor((secs % 3600) / 60);
-    const s = secs % 60;
-    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-    return `${m}:${String(s).padStart(2, '0')}`;
   }
 
   function toggleFullscreen() {
@@ -102,7 +95,7 @@
         <MetricCard label="Speed" value={$currentSpeed != null ? formatSpeed($currentSpeed, $unitSystem) : null} unit={$speedUnit} size="lg" />
         <MetricCard
           label="Time"
-          value={$liveMetrics ? formatTime($liveMetrics.elapsed_secs) : '--'}
+          value={$liveMetrics ? formatDuration($liveMetrics.elapsed_secs) : '--'}
           size="lg"
         />
       </div>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -3,6 +3,7 @@
   import type { SessionSummary } from '$lib/tauri';
   import { api, extractError } from '$lib/tauri';
   import ActivityModal from '$lib/components/ActivityModal.svelte';
+  import { formatDuration, formatDateLong as formatDate, formatDateShort, formatTime, autoTitle } from '$lib/utils/format';
 
   let sessions = $state<SessionSummary[]>([]);
   let loading = $state(true);
@@ -38,14 +39,6 @@
     localStorage.setItem('historyView', mode);
   }
 
-  function autoTitle(startTime: string): string {
-    const hour = new Date(startTime).getHours();
-    if (hour >= 5 && hour < 12) return 'Morning Ride';
-    if (hour >= 12 && hour < 17) return 'Afternoon Ride';
-    if (hour >= 17 && hour < 21) return 'Evening Ride';
-    return 'Night Ride';
-  }
-
   function displayTitle(session: SessionSummary): string {
     return session.title ?? autoTitle(session.start_time);
   }
@@ -56,29 +49,6 @@
     tempo: 'Tempo', recovery: 'Recovery', race: 'Race', test: 'Test',
     warmup: 'Warmup', group_ride: 'Group Ride', free_ride: 'Free Ride', other: 'Other',
   };
-
-  function formatDate(iso: string): string {
-    const d = new Date(iso);
-    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
-  }
-
-  function formatDateShort(iso: string): string {
-    const d = new Date(iso);
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  }
-
-  function formatTime(iso: string): string {
-    const d = new Date(iso);
-    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-  }
-
-  function formatDuration(secs: number): string {
-    const h = Math.floor(secs / 3600);
-    const m = Math.floor((secs % 3600) / 60);
-    const s = secs % 60;
-    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-    return `${m}:${String(s).padStart(2, '0')}`;
-  }
 
   function rpeColor(value: number): string {
     if (value <= 5) {


### PR DESCRIPTION
## Summary
- Create `$lib/utils/format.ts` with `formatDuration`, `autoTitle`, `formatDate`, `formatDateLong`, `formatDateShort`, `formatTime`
- Remove duplicate implementations from `ActivityModal.svelte`, `history/+page.svelte`, `+page.svelte`
- Net -22 lines (39 added in shared module, 61 removed from consumers)

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings

Closes #20