### PR TITLE
Add get_session and get_session_analysis Tauri commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,8 @@ pub fn run() {
             commands::resume_session,
             commands::get_live_metrics,
             commands::list_sessions,
+            commands::get_session,
+            commands::get_session_analysis,
             commands::get_user_config,
             commands::save_user_config,
             commands::set_trainer_power,


### PR DESCRIPTION
## Summary
- `get_session` command exposes existing `storage.get_session()` to the frontend for instant summary loading
- `get_session_analysis` command loads sensor data via `spawn_blocking` and runs `compute_analysis` for time-series, power curve, and zone distribution
- Both commands validate session IDs against path traversal

## Test plan
- [x] All 175 tests passing (`cargo test`)
- [ ] Integration with frontend API layer (issue #46)

Closes #45