### PR TITLE
Fix bincode deserialization, chart reactivity, and layout

### DIFF
--- a/src-tauri/src/device/types.rs
+++ b/src-tauri/src/device/types.rs
@@ -74,7 +74,6 @@ pub enum SensorReading {
         device_id: String,
         /// Right pedal contribution %. Present when pedal differentiation is reported.
         /// ~50% = combined (L+R), ~100% = right pedal only.
-        #[serde(skip_serializing_if = "Option::is_none")]
         pedal_balance: Option<u8>,
     },
     HeartRate {

--- a/src/lib/components/PowerCurve.svelte
+++ b/src/lib/components/PowerCurve.svelte
@@ -11,7 +11,7 @@
   let { powerCurve, ftp = null }: Props = $props();
 
   let chartEl: HTMLDivElement;
-  let chart: echarts.ECharts | null = null;
+  let chart = $state<echarts.ECharts | null>(null);
 
   function formatDuration(secs: number): string {
     if (secs < 60) return `${secs}s`;

--- a/src/lib/components/SessionTimeseries.svelte
+++ b/src/lib/components/SessionTimeseries.svelte
@@ -13,7 +13,7 @@
   let { timeseries, smoothing = 1, units = 'metric' }: Props = $props();
 
   let chartEl: HTMLDivElement;
-  let chart: echarts.ECharts | null = null;
+  let chart = $state<echarts.ECharts | null>(null);
 
   const COLORS = {
     power: '#ff4d6d',

--- a/src/routes/history/[id]/+page.svelte
+++ b/src/routes/history/[id]/+page.svelte
@@ -248,7 +248,7 @@
 
 <style>
   .page {
-    max-width: 960px;
+    max-width: 100%;
     padding-bottom: var(--space-3xl);
   }
 
@@ -443,12 +443,12 @@
 
   .timeseries-wrap {
     position: relative;
-    height: 300px;
+    height: 400px;
   }
 
   .panel-wrap {
     position: relative;
-    height: 260px;
+    height: 350px;
   }
 
   .chart-skeleton, .chart-empty {


### PR DESCRIPTION
## Summary
- Remove `skip_serializing_if` from `pedal_balance` on `SensorReading::Power` — incompatible with bincode's non-self-describing format, causing "tag for enum is not valid" errors on every session
- Add `LegacySensorReading` fallback deserializer in `load_sensor_data` for old `.bin` files written without the `pedal_balance` field
- Change `chart` variable to `$state` in SessionTimeseries and PowerCurve so `$effect` re-runs after `onMount` initializes ECharts (fixes charts showing axes but no data)
- Use full-width layout and increase chart heights for session detail page

## Test plan
- [ ] `cargo test --lib` passes (175 tests)
- [ ] `npm run check` passes
- [ ] Open a session detail page — charts render with data
- [ ] Old sessions (recorded before pedal_balance field) load without errors