### PR TITLE
Fix bidirectional state coupling between devices page and store

### DIFF
--- a/src/lib/stores/devices.ts
+++ b/src/lib/stores/devices.ts
@@ -21,6 +21,43 @@ export async function refreshDevices() {
   }
 }
 
+export async function scanDevices(): Promise<DeviceInfo[]> {
+  const devices = await api.scanDevices();
+  connectedDevices.set(devices);
+  return devices;
+}
+
+export async function connectDevice(deviceId: string): Promise<DeviceInfo> {
+  const updated = await api.connectDevice(deviceId);
+  connectedDevices.update((devices) =>
+    devices.map((d) => (d.id === deviceId ? updated : d))
+  );
+  return updated;
+}
+
+export async function disconnectDevice(deviceId: string): Promise<void> {
+  await api.disconnectDevice(deviceId);
+  connectedDevices.update((devices) =>
+    devices.map((d) =>
+      d.id === deviceId ? { ...d, status: 'Disconnected' as const } : d
+    )
+  );
+}
+
+export async function unlinkDevices(
+  deviceId: string,
+  deviceGroup: string | null | undefined
+): Promise<void> {
+  await api.unlinkDevices(deviceId);
+  if (deviceGroup) {
+    connectedDevices.update((devices) =>
+      devices.map((d) =>
+        d.device_group === deviceGroup ? { ...d, device_group: null } : d
+      )
+    );
+  }
+}
+
 // --- Reconnection state ---
 
 export interface ReconnectingDevice {


### PR DESCRIPTION
## Summary
- Make `connectedDevices` store the single source of truth by moving API calls (scan, connect, disconnect, unlink) into store action functions
- Eliminate the devices page's local `devices` state, `syncStore()` bridge, and subscription that caused stale overwrites and startup races
- Fixes #15

## Test plan
- [ ] `npm run check` passes
- [ ] `npm run build` passes
- [ ] Scan finds devices and updates both page and nav rail
- [ ] Connect/disconnect updates device cards and nav rail DeviceStatus
- [ ] Backend disconnect event (e.g. pull USB stick) updates both page and nav rail
- [ ] Reconnect event updates both