### PR TITLE
Reset initializing flag in stopSensorListening

### DIFF
--- a/src/lib/stores/sensor.ts
+++ b/src/lib/stores/sensor.ts
@@ -64,6 +64,7 @@ export async function startSensorListening() {
 }
 
 export function stopSensorListening() {
+  initializing = false;
   if (unlistenFn) {
     unlistenFn();
     unlistenFn = null;


### PR DESCRIPTION
## Summary
- Reset `initializing = false` at the top of `stopSensorListening()` so that if the layout unmounts mid-await, the flag doesn't stay stuck and permanently prevent sensor listening on re-mount
- Fixes #65

## Test plan
- [ ] `npm run check` passes
- [ ] Sensor data flows after navigating away from and back to the app