### PR TITLE
Remove skip_serializing_if from SessionSummary fields

### DIFF
--- a/src-tauri/src/session/types.rs
+++ b/src-tauri/src/session/types.rs
@@ -52,13 +52,9 @@ pub struct SessionSummary {
     pub max_hr: Option<u8>,
     pub avg_cadence: Option<f32>,
     pub avg_speed: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub activity_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rpe: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
 }
 


### PR DESCRIPTION
## Summary
- Remove `#[serde(skip_serializing_if = "Option::is_none")]` from `title`, `activity_type`, `rpe`, and `notes` on `SessionSummary`
- These attributes are incompatible with bincode and previously caused corruption on `SensorReading::Power::pedal_balance`
- JSON serializes `None` as `null` correctly without them
- Prevents the same latent corruption if `SessionSummary` is ever routed through bincode

## Test plan
- [x] `cargo test --lib session` — all 78 tests pass
- [ ] Autosave/recover cycle still works (JSON format unchanged for consumers)

Closes #75