### PR TITLE
Add Analytics page with PMC chart and weekly trends

### DIFF
--- a/src/lib/components/PmcChart.svelte
+++ b/src/lib/components/PmcChart.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+  import type { PmcDay } from '$lib/utils/analytics';
+
+  interface Props {
+    pmcData: PmcDay[];
+  }
+
+  let { pmcData }: Props = $props();
+
+  let chartEl: HTMLDivElement;
+  let chart = $state<echarts.ECharts | null>(null);
+
+  function getBaseOption(): echarts.EChartsOption {
+    return {
+      backgroundColor: 'transparent',
+      animation: false,
+      grid: {
+        left: 50,
+        right: 20,
+        top: 40,
+        bottom: 70,
+      },
+      legend: {
+        top: 4,
+        textStyle: { color: '#a0a0b8', fontSize: 12, fontFamily: 'Outfit, sans-serif' },
+        itemWidth: 16,
+        itemHeight: 2,
+        itemGap: 16,
+      },
+      tooltip: {
+        trigger: 'axis',
+        backgroundColor: '#1c1c30',
+        borderColor: 'rgba(255,255,255,0.08)',
+        textStyle: { color: '#f0f0f5', fontSize: 13, fontFamily: 'IBM Plex Mono, monospace' },
+        formatter(params: unknown) {
+          const items = params as { seriesName: string; value: number; axisValueLabel: string; color: string }[];
+          if (!Array.isArray(items) || items.length === 0) return '';
+          let html = `<div style="margin-bottom:4px;font-weight:600">${items[0].axisValueLabel}</div>`;
+          for (const item of items) {
+            html += `<div style="display:flex;align-items:center;gap:6px">`;
+            html += `<span style="width:8px;height:8px;border-radius:50%;background:${item.color};display:inline-block"></span>`;
+            html += `${item.seriesName}: <b>${item.value.toFixed(1)}</b></div>`;
+          }
+          return html;
+        },
+      },
+      dataZoom: [
+        {
+          type: 'slider',
+          bottom: 8,
+          height: 24,
+          borderColor: 'rgba(255,255,255,0.06)',
+          backgroundColor: 'rgba(255,255,255,0.02)',
+          fillerColor: 'rgba(255,255,255,0.04)',
+          handleStyle: { color: '#70708a' },
+          textStyle: { color: '#70708a', fontSize: 10 },
+          dataBackground: {
+            lineStyle: { color: 'rgba(255,255,255,0.1)' },
+            areaStyle: { color: 'rgba(255,255,255,0.03)' },
+          },
+        },
+        { type: 'inside' },
+      ],
+      xAxis: {
+        type: 'category',
+        boundaryGap: false,
+        axisLine: { lineStyle: { color: 'rgba(255,255,255,0.06)' } },
+        axisTick: { show: false },
+        axisLabel: { color: '#70708a', fontSize: 10 },
+        data: [],
+      },
+      yAxis: {
+        type: 'value',
+        splitLine: { lineStyle: { color: 'rgba(255,255,255,0.04)' } },
+        axisLine: { show: false },
+        axisLabel: { color: '#70708a', fontSize: 10 },
+      },
+      series: [
+        {
+          name: 'CTL (Fitness)',
+          type: 'line',
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: '#4a90d9', width: 2 },
+          itemStyle: { color: '#4a90d9' },
+          areaStyle: {
+            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+              { offset: 0, color: 'rgba(74, 144, 217, 0.2)' },
+              { offset: 1, color: 'rgba(74, 144, 217, 0)' },
+            ]),
+          },
+          data: [],
+        },
+        {
+          name: 'ATL (Fatigue)',
+          type: 'line',
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: '#ff4d6d', width: 2 },
+          itemStyle: { color: '#ff4d6d' },
+          data: [],
+        },
+        {
+          name: 'TSB (Form)',
+          type: 'line',
+          smooth: true,
+          symbol: 'none',
+          lineStyle: { color: '#4caf50', width: 2 },
+          itemStyle: { color: '#4caf50' },
+          markLine: {
+            silent: true,
+            symbol: 'none',
+            lineStyle: { color: '#4caf50', type: 'dashed', width: 1, opacity: 0.5 },
+            data: [{ yAxis: 0 }],
+          },
+          data: [],
+        },
+      ],
+    };
+  }
+
+  onMount(() => {
+    let observer: ResizeObserver | undefined;
+    let disposed = false;
+    document.fonts.ready.then(() => {
+      if (disposed) return;
+      chart = echarts.init(chartEl, undefined, { renderer: 'canvas' });
+      chart.setOption(getBaseOption());
+
+      observer = new ResizeObserver(() => chart?.resize());
+      observer.observe(chartEl);
+    });
+
+    return () => {
+      disposed = true;
+      observer?.disconnect();
+      chart?.dispose();
+      chart = null;
+    };
+  });
+
+  $effect(() => {
+    if (!chart || pmcData.length === 0) return;
+
+    chart.setOption({
+      xAxis: {
+        data: pmcData.map((d) => d.date),
+        axisLabel: {
+          interval: Math.max(0, Math.floor(pmcData.length / 8) - 1),
+        },
+      },
+      series: [
+        { data: pmcData.map((d) => Math.round(d.ctl * 10) / 10) },
+        { data: pmcData.map((d) => Math.round(d.atl * 10) / 10) },
+        { data: pmcData.map((d) => Math.round(d.tsb * 10) / 10) },
+      ],
+    });
+  });
+</script>
+
+<div class="chart-wrapper">
+  <div bind:this={chartEl} class="chart"></div>
+</div>
+
+<style>
+  .chart-wrapper {
+    background: var(--bg-surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-subtle);
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chart {
+    width: 100%;
+    height: 400px;
+  }
+</style>

--- a/src/lib/components/TrendChart.svelte
+++ b/src/lib/components/TrendChart.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as echarts from 'echarts';
+
+  interface Props {
+    labels: string[];
+    barData: number[];
+    barLabel: string;
+    barColor: string;
+    barUnit?: string;
+    lineData?: (number | null)[];
+    lineLabel?: string;
+    lineColor?: string;
+    lineUnit?: string;
+  }
+
+  let {
+    labels,
+    barData,
+    barLabel,
+    barColor,
+    barUnit = '',
+    lineData,
+    lineLabel,
+    lineColor,
+    lineUnit = '',
+  }: Props = $props();
+
+  let chartEl: HTMLDivElement;
+  let chart = $state<echarts.ECharts | null>(null);
+
+  const hasLine = $derived(lineData != null && lineLabel != null && lineColor != null);
+
+  function getBaseOption(): echarts.EChartsOption {
+    const yAxes: echarts.EChartsOption['yAxis'] = [
+      {
+        type: 'value',
+        name: barUnit ? `${barLabel} (${barUnit})` : barLabel,
+        nameTextStyle: { color: '#70708a', fontSize: 10 },
+        min: 0,
+        splitLine: { lineStyle: { color: 'rgba(255,255,255,0.04)' } },
+        axisLine: { show: false },
+        axisLabel: { color: '#70708a', fontSize: 10 },
+      },
+    ];
+
+    if (hasLine) {
+      yAxes.push({
+        type: 'value',
+        name: lineUnit ? `${lineLabel} (${lineUnit})` : lineLabel,
+        nameTextStyle: { color: '#70708a', fontSize: 10 },
+        min: 0,
+        splitLine: { show: false },
+        axisLine: { show: false },
+        axisLabel: { color: '#70708a', fontSize: 10 },
+      });
+    }
+
+    const series: echarts.SeriesOption[] = [
+      {
+        name: barLabel,
+        type: 'bar',
+        yAxisIndex: 0,
+        itemStyle: {
+          color: barColor,
+          opacity: 0.7,
+          borderRadius: [4, 4, 0, 0],
+        },
+        data: [],
+      },
+    ];
+
+    if (hasLine) {
+      series.push({
+        name: lineLabel,
+        type: 'line',
+        yAxisIndex: 1,
+        smooth: true,
+        symbol: 'circle',
+        symbolSize: 4,
+        lineStyle: { color: lineColor, width: 2 },
+        itemStyle: { color: lineColor },
+        data: [],
+      });
+    }
+
+    return {
+      backgroundColor: 'transparent',
+      animation: false,
+      grid: {
+        left: 50,
+        right: hasLine ? 50 : 20,
+        top: 40,
+        bottom: 30,
+      },
+      legend: {
+        top: 4,
+        textStyle: { color: '#a0a0b8', fontSize: 12, fontFamily: 'Outfit, sans-serif' },
+        itemWidth: 16,
+        itemHeight: 2,
+        itemGap: 16,
+      },
+      tooltip: {
+        trigger: 'axis',
+        backgroundColor: '#1c1c30',
+        borderColor: 'rgba(255,255,255,0.08)',
+        textStyle: { color: '#f0f0f5', fontSize: 13, fontFamily: 'IBM Plex Mono, monospace' },
+      },
+      xAxis: {
+        type: 'category',
+        axisLine: { lineStyle: { color: 'rgba(255,255,255,0.06)' } },
+        axisTick: { show: false },
+        axisLabel: { color: '#70708a', fontSize: 10, rotate: labels.length > 12 ? 45 : 0 },
+        data: [],
+      },
+      yAxis: yAxes,
+      series,
+    };
+  }
+
+  onMount(() => {
+    let observer: ResizeObserver | undefined;
+    let disposed = false;
+    document.fonts.ready.then(() => {
+      if (disposed) return;
+      chart = echarts.init(chartEl, undefined, { renderer: 'canvas' });
+      chart.setOption(getBaseOption());
+
+      observer = new ResizeObserver(() => chart?.resize());
+      observer.observe(chartEl);
+    });
+
+    return () => {
+      disposed = true;
+      observer?.disconnect();
+      chart?.dispose();
+      chart = null;
+    };
+  });
+
+  $effect(() => {
+    if (!chart || labels.length === 0) return;
+
+    const seriesData: echarts.SeriesOption[] = [
+      { data: barData },
+    ];
+    if (hasLine) {
+      seriesData.push({ data: lineData!.map((v) => v != null ? Math.round(v * 10) / 10 : null) });
+    }
+
+    chart.setOption({
+      xAxis: { data: labels },
+      series: seriesData,
+    });
+  });
+</script>
+
+<div class="chart-wrapper">
+  <div bind:this={chartEl} class="chart"></div>
+</div>
+
+<style>
+  .chart-wrapper {
+    background: var(--bg-surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border-subtle);
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chart {
+    width: 100%;
+    height: 300px;
+  }
+</style>

--- a/src/lib/utils/analytics.test.ts
+++ b/src/lib/utils/analytics.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionSummary } from '$lib/tauri';
+import {
+  computePmc,
+  computeWeeklyTrends,
+  extractFtpProgression,
+  toDateKey,
+  weekMonday,
+} from './analytics';
+
+/** Helper to build a minimal SessionSummary for testing. */
+function session(
+  overrides: Partial<SessionSummary> & { start_time: string },
+): SessionSummary {
+  return {
+    id: 'test',
+    duration_secs: 3600,
+    ftp: null,
+    avg_power: null,
+    max_power: null,
+    normalized_power: null,
+    tss: null,
+    intensity_factor: null,
+    avg_hr: null,
+    max_hr: null,
+    avg_cadence: null,
+    avg_speed: null,
+    ...overrides,
+  };
+}
+
+function assertApprox(actual: number, expected: number, epsilon: number, msg?: string) {
+  expect(
+    Math.abs(actual - expected),
+    `${msg ?? ''} expected ≈${expected}, got ${actual}`,
+  ).toBeLessThanOrEqual(epsilon);
+}
+
+describe('toDateKey', () => {
+  it('extracts date from ISO datetime', () => {
+    expect(toDateKey('2025-03-15T14:30:00Z')).toBe('2025-03-15');
+  });
+
+  it('extracts date from ISO with timezone offset', () => {
+    expect(toDateKey('2025-03-15T14:30:00+02:00')).toBe('2025-03-15');
+  });
+});
+
+describe('weekMonday', () => {
+  it('returns same day for a Monday', () => {
+    // 2025-01-06 is a Monday
+    const result = weekMonday(new Date('2025-01-06T12:00:00Z'));
+    expect(toDateKey(result.toISOString())).toBe('2025-01-06');
+  });
+
+  it('returns previous Monday for a Wednesday', () => {
+    // 2025-01-08 is a Wednesday → Monday is 2025-01-06
+    const result = weekMonday(new Date('2025-01-08T12:00:00Z'));
+    expect(toDateKey(result.toISOString())).toBe('2025-01-06');
+  });
+
+  it('returns previous Monday for a Saturday', () => {
+    // 2025-01-11 is a Saturday → Monday is 2025-01-06
+    const result = weekMonday(new Date('2025-01-11T12:00:00Z'));
+    expect(toDateKey(result.toISOString())).toBe('2025-01-06');
+  });
+
+  it('returns previous Monday for a Sunday', () => {
+    // 2025-01-12 is a Sunday → Monday is 2025-01-06
+    const result = weekMonday(new Date('2025-01-12T12:00:00Z'));
+    expect(toDateKey(result.toISOString())).toBe('2025-01-06');
+  });
+});
+
+describe('computePmc', () => {
+  it('returns empty for no sessions', () => {
+    expect(computePmc([])).toEqual([]);
+  });
+
+  it('computes single-session PMC correctly', () => {
+    // TSS=100 on day 0
+    // CTL = 0 + (100 - 0) / 42 = 100/42 ≈ 2.381
+    // ATL = 0 + (100 - 0) / 7  = 100/7  ≈ 14.286
+    // TSB = CTL - ATL ≈ 2.381 - 14.286 ≈ -11.905
+    const sessions = [session({ start_time: new Date().toISOString(), tss: 100 })];
+    const pmc = computePmc(sessions);
+    const last = pmc[pmc.length - 1];
+
+    assertApprox(last.ctl, 100 / 42, 0.01, 'CTL');
+    assertApprox(last.atl, 100 / 7, 0.01, 'ATL');
+    assertApprox(last.tsb, 100 / 42 - 100 / 7, 0.01, 'TSB');
+  });
+
+  it('sums TSS from two sessions on the same day', () => {
+    const today = new Date().toISOString();
+    const sessions = [
+      session({ id: 'a', start_time: today, tss: 60 }),
+      session({ id: 'b', start_time: today, tss: 40 }),
+    ];
+    const pmc = computePmc(sessions);
+    const last = pmc[pmc.length - 1];
+
+    // Combined TSS = 100, same result as single 100-TSS session
+    assertApprox(last.ctl, 100 / 42, 0.01, 'CTL');
+    assertApprox(last.atl, 100 / 7, 0.01, 'ATL');
+  });
+
+  it('all-null TSS keeps CTL/ATL/TSB at zero', () => {
+    const sessions = [
+      session({ start_time: new Date().toISOString(), tss: null }),
+    ];
+    const pmc = computePmc(sessions);
+    const last = pmc[pmc.length - 1];
+
+    expect(last.ctl).toBe(0);
+    expect(last.atl).toBe(0);
+    expect(last.tsb).toBe(0);
+  });
+
+  it('multi-day PMC accumulates correctly', () => {
+    // Day 0: TSS=100 → CTL = 100/42, ATL = 100/7
+    // Day 1: TSS=0   → CTL = CTL_0 + (0 - CTL_0)/42 = CTL_0 * (41/42)
+    //                   ATL = ATL_0 + (0 - ATL_0)/7  = ATL_0 * (6/7)
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const sessions = [
+      session({ start_time: yesterday.toISOString(), tss: 100 }),
+    ];
+    const pmc = computePmc(sessions);
+
+    // Should have 2 days
+    expect(pmc.length).toBe(2);
+
+    const ctl0 = 100 / 42;
+    const atl0 = 100 / 7;
+    const ctl1 = ctl0 * (41 / 42);
+    const atl1 = atl0 * (6 / 7);
+
+    assertApprox(pmc[0].ctl, ctl0, 0.01, 'day 0 CTL');
+    assertApprox(pmc[0].atl, atl0, 0.01, 'day 0 ATL');
+    assertApprox(pmc[1].ctl, ctl1, 0.01, 'day 1 CTL');
+    assertApprox(pmc[1].atl, atl1, 0.01, 'day 1 ATL');
+    assertApprox(pmc[1].tsb, ctl1 - atl1, 0.01, 'day 1 TSB');
+  });
+});
+
+describe('computeWeeklyTrends', () => {
+  it('returns empty for no sessions', () => {
+    expect(computeWeeklyTrends([])).toEqual([]);
+  });
+
+  it('groups sessions into correct week buckets', () => {
+    // Week 1: Mon 2025-01-06
+    //   Session A: TSS=50, power=200, hr=140, duration=3600
+    //   Session B: TSS=70, power=220, hr=null, duration=5400
+    // Week 2: Mon 2025-01-13
+    //   Session C: TSS=80, power=null, hr=150, duration=7200
+    const sessions = [
+      session({
+        id: 'a',
+        start_time: '2025-01-07T10:00:00Z', // Tuesday wk1
+        tss: 50,
+        avg_power: 200,
+        avg_hr: 140,
+        duration_secs: 3600,
+      }),
+      session({
+        id: 'b',
+        start_time: '2025-01-09T10:00:00Z', // Thursday wk1
+        tss: 70,
+        avg_power: 220,
+        avg_hr: null,
+        duration_secs: 5400,
+      }),
+      session({
+        id: 'c',
+        start_time: '2025-01-14T10:00:00Z', // Tuesday wk2
+        tss: 80,
+        avg_power: null,
+        avg_hr: 150,
+        duration_secs: 7200,
+      }),
+    ];
+
+    const weeks = computeWeeklyTrends(sessions);
+    expect(weeks.length).toBe(2);
+
+    // Week 1
+    expect(weeks[0].weekStart).toBe('2025-01-06');
+    expect(weeks[0].totalTss).toBe(120); // 50+70
+    assertApprox(weeks[0].avgPower!, 210, 0.1, 'wk1 avgPower'); // (200+220)/2
+    assertApprox(weeks[0].avgHr!, 140, 0.1, 'wk1 avgHr'); // only 1 non-null
+    expect(weeks[0].sessionCount).toBe(2);
+    expect(weeks[0].totalDurationSecs).toBe(9000); // 3600+5400
+
+    // Week 2
+    expect(weeks[1].weekStart).toBe('2025-01-13');
+    expect(weeks[1].totalTss).toBe(80);
+    expect(weeks[1].avgPower).toBeNull();
+    assertApprox(weeks[1].avgHr!, 150, 0.1, 'wk2 avgHr');
+    expect(weeks[1].sessionCount).toBe(1);
+    expect(weeks[1].totalDurationSecs).toBe(7200);
+  });
+
+  it('excludes null metrics from averages (not counted as 0)', () => {
+    const sessions = [
+      session({
+        id: 'a',
+        start_time: '2025-01-07T10:00:00Z',
+        avg_power: 200,
+        avg_hr: null,
+      }),
+      session({
+        id: 'b',
+        start_time: '2025-01-08T10:00:00Z',
+        avg_power: null,
+        avg_hr: null,
+      }),
+    ];
+
+    const weeks = computeWeeklyTrends(sessions);
+    // avg_power should be 200 (only one valid), not 100 (200+0)/2
+    assertApprox(weeks[0].avgPower!, 200, 0.1, 'power average excludes nulls');
+    expect(weeks[0].avgHr).toBeNull();
+  });
+});
+
+describe('extractFtpProgression', () => {
+  it('returns empty for no sessions', () => {
+    expect(extractFtpProgression([])).toEqual([]);
+  });
+
+  it('returns empty when all FTP are null', () => {
+    const sessions = [
+      session({ start_time: '2025-01-01T00:00:00Z', ftp: null }),
+    ];
+    expect(extractFtpProgression(sessions)).toEqual([]);
+  });
+
+  it('emits change points only', () => {
+    const sessions = [
+      session({ id: 'a', start_time: '2025-01-01T00:00:00Z', ftp: 200 }),
+      session({ id: 'b', start_time: '2025-02-01T00:00:00Z', ftp: 200 }),
+      session({ id: 'c', start_time: '2025-03-01T00:00:00Z', ftp: 220 }),
+      session({ id: 'd', start_time: '2025-04-01T00:00:00Z', ftp: 220 }),
+      session({ id: 'e', start_time: '2025-05-01T00:00:00Z', ftp: 210 }),
+    ];
+
+    const points = extractFtpProgression(sessions);
+    // Change points: 200 (first), 220 (change), 210 (change)
+    // Last session (210) is already a change point, so 3 total
+    expect(points).toEqual([
+      { date: '2025-01-01', ftp: 200 },
+      { date: '2025-03-01', ftp: 220 },
+      { date: '2025-05-01', ftp: 210 },
+    ]);
+  });
+
+  it('always includes last session even if FTP unchanged', () => {
+    const sessions = [
+      session({ id: 'a', start_time: '2025-01-01T00:00:00Z', ftp: 200 }),
+      session({ id: 'b', start_time: '2025-06-01T00:00:00Z', ftp: 200 }),
+    ];
+
+    const points = extractFtpProgression(sessions);
+    // First is a change point, last has same FTP but different date → should be emitted
+    expect(points).toEqual([
+      { date: '2025-01-01', ftp: 200 },
+      { date: '2025-06-01', ftp: 200 },
+    ]);
+  });
+});

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,0 +1,169 @@
+import type { SessionSummary } from '$lib/tauri';
+
+export interface PmcDay {
+  date: string;
+  tss: number;
+  ctl: number;
+  atl: number;
+  tsb: number;
+}
+
+export interface WeekBucket {
+  weekStart: string;
+  totalTss: number;
+  avgPower: number | null;
+  avgHr: number | null;
+  sessionCount: number;
+  totalDurationSecs: number;
+}
+
+export interface FtpPoint {
+  date: string;
+  ftp: number;
+}
+
+/** Extract YYYY-MM-DD from an ISO string via slicing (avoids timezone issues). */
+export function toDateKey(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+/** Get the Monday of the ISO week for a given Date. */
+export function weekMonday(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getUTCDay();
+  // Sunday=0 → offset 6, Monday=1 → 0, Tuesday=2 → 1, etc.
+  const offset = day === 0 ? 6 : day - 1;
+  d.setUTCDate(d.getUTCDate() - offset);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Compute a Performance Management Chart from session data.
+ * Walks each calendar day from the first session to today, applying
+ * exponential moving averages for CTL (42-day) and ATL (7-day).
+ */
+export function computePmc(sessions: SessionSummary[]): PmcDay[] {
+  if (sessions.length === 0) return [];
+
+  // Sort ascending by start_time
+  const sorted = [...sessions].sort(
+    (a, b) => a.start_time.localeCompare(b.start_time),
+  );
+
+  // Group TSS by date key
+  const tssByDate = new Map<string, number>();
+  for (const s of sorted) {
+    const key = toDateKey(s.start_time);
+    tssByDate.set(key, (tssByDate.get(key) ?? 0) + (s.tss ?? 0));
+  }
+
+  const firstDate = toDateKey(sorted[0].start_time);
+  const today = toDateKey(new Date().toISOString());
+
+  const result: PmcDay[] = [];
+  let ctl = 0;
+  let atl = 0;
+
+  // Walk each day from first session to today
+  const current = new Date(firstDate + 'T00:00:00Z');
+  const end = new Date(today + 'T00:00:00Z');
+
+  while (current <= end) {
+    const key = toDateKey(current.toISOString());
+    const tss = tssByDate.get(key) ?? 0;
+
+    ctl = ctl + (tss - ctl) / 42;
+    atl = atl + (tss - atl) / 7;
+    const tsb = ctl - atl;
+
+    result.push({ date: key, tss, ctl, atl, tsb });
+
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+
+  return result;
+}
+
+/** Group sessions by ISO week (Monday start) and compute aggregates. */
+export function computeWeeklyTrends(sessions: SessionSummary[]): WeekBucket[] {
+  if (sessions.length === 0) return [];
+
+  const buckets = new Map<
+    string,
+    {
+      totalTss: number;
+      powers: number[];
+      hrs: number[];
+      count: number;
+      totalDuration: number;
+    }
+  >();
+
+  for (const s of sessions) {
+    const date = new Date(s.start_time);
+    const monday = weekMonday(date);
+    const key = toDateKey(monday.toISOString());
+
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { totalTss: 0, powers: [], hrs: [], count: 0, totalDuration: 0 };
+      buckets.set(key, bucket);
+    }
+
+    bucket.totalTss += s.tss ?? 0;
+    if (s.avg_power != null) bucket.powers.push(s.avg_power);
+    if (s.avg_hr != null) bucket.hrs.push(s.avg_hr);
+    bucket.count += 1;
+    bucket.totalDuration += s.duration_secs;
+  }
+
+  return [...buckets.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([weekStart, b]) => ({
+      weekStart,
+      totalTss: b.totalTss,
+      avgPower:
+        b.powers.length > 0
+          ? b.powers.reduce((a, v) => a + v, 0) / b.powers.length
+          : null,
+      avgHr:
+        b.hrs.length > 0
+          ? b.hrs.reduce((a, v) => a + v, 0) / b.hrs.length
+          : null,
+      sessionCount: b.count,
+      totalDurationSecs: b.totalDuration,
+    }));
+}
+
+/** Extract FTP change points: emit when FTP value changes from previous. Always emit first and last. */
+export function extractFtpProgression(sessions: SessionSummary[]): FtpPoint[] {
+  const sorted = [...sessions]
+    .filter((s) => s.ftp != null)
+    .sort((a, b) => a.start_time.localeCompare(b.start_time));
+
+  if (sorted.length === 0) return [];
+
+  const result: FtpPoint[] = [];
+  let prevFtp: number | null = null;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const ftp = sorted[i].ftp!;
+    if (ftp !== prevFtp) {
+      result.push({ date: toDateKey(sorted[i].start_time), ftp });
+      prevFtp = ftp;
+    }
+  }
+
+  // Always include the last point if it wasn't already added as a change
+  const lastSession = sorted[sorted.length - 1];
+  const lastResult = result[result.length - 1];
+  if (lastResult.date !== toDateKey(lastSession.start_time)) {
+    result.push({
+      date: toDateKey(lastSession.start_time),
+      ftp: lastSession.ftp!,
+    });
+  }
+
+  return result;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -72,6 +72,7 @@
     { href: '/', label: 'Ride', icon: 'ride' },
     { href: '/devices', label: 'Devices', icon: 'devices' },
     { href: '/history', label: 'History', icon: 'history' },
+    { href: '/analytics', label: 'Analytics', icon: 'analytics' },
     { href: '/settings', label: 'Settings', icon: 'settings' },
   ];
 </script>
@@ -114,6 +115,10 @@
                 <rect x="4" y="14" width="3" height="6" rx="1"/>
                 <rect x="10.5" y="8" width="3" height="12" rx="1"/>
                 <rect x="17" y="4" width="3" height="16" rx="1"/>
+              </svg>
+            {:else if item.icon === 'analytics'}
+              <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
               </svg>
             {:else if item.icon === 'settings'}
               <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">

--- a/src/routes/analytics/+page.svelte
+++ b/src/routes/analytics/+page.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { SessionSummary } from '$lib/tauri';
+  import { api, extractError } from '$lib/tauri';
+  import { computePmc, computeWeeklyTrends, extractFtpProgression } from '$lib/utils/analytics';
+  import MetricCard from '$lib/components/MetricCard.svelte';
+  import PmcChart from '$lib/components/PmcChart.svelte';
+  import TrendChart from '$lib/components/TrendChart.svelte';
+
+  let sessions = $state<SessionSummary[]>([]);
+  let loading = $state(true);
+  let error = $state('');
+
+  onMount(async () => {
+    try {
+      sessions = await api.listSessions();
+    } catch (e) {
+      error = extractError(e);
+    } finally {
+      loading = false;
+    }
+  });
+
+  let pmcData = $derived(computePmc(sessions));
+  let weeklyData = $derived(computeWeeklyTrends(sessions));
+  let ftpPoints = $derived(extractFtpProgression(sessions));
+
+  let currentCtl = $derived(pmcData.length > 0 ? Math.round(pmcData[pmcData.length - 1].ctl) : null);
+  let currentAtl = $derived(pmcData.length > 0 ? Math.round(pmcData[pmcData.length - 1].atl) : null);
+  let currentTsb = $derived(pmcData.length > 0 ? Math.round(pmcData[pmcData.length - 1].tsb) : null);
+  let currentFtp = $derived.by(() => {
+    const withFtp = sessions.filter((s) => s.ftp != null);
+    if (withFtp.length === 0) return null;
+    const latest = withFtp.sort((a, b) => b.start_time.localeCompare(a.start_time))[0];
+    return latest.ftp;
+  });
+  let thisWeekTss = $derived.by(() => {
+    if (weeklyData.length === 0) return null;
+    const lastBucket = weeklyData[weeklyData.length - 1];
+    // Check if the last bucket is this week
+    const now = new Date();
+    const day = now.getUTCDay();
+    const offset = day === 0 ? 6 : day - 1;
+    const monday = new Date(now);
+    monday.setUTCDate(monday.getUTCDate() - offset);
+    monday.setUTCHours(0, 0, 0, 0);
+    const thisMonday = monday.toISOString().slice(0, 10);
+    return lastBucket.weekStart === thisMonday ? Math.round(lastBucket.totalTss) : 0;
+  });
+</script>
+
+<div class="page">
+  <div class="page-header">
+    <h1>Analytics</h1>
+  </div>
+
+  {#if error}
+    <div class="error">{error}</div>
+  {/if}
+
+  {#if loading}
+    <p class="empty">Loading analytics...</p>
+  {:else if sessions.length === 0}
+    <p class="empty">No sessions yet. Complete some rides to see your training trends.</p>
+  {:else}
+    <div class="summary-cards">
+      <MetricCard label="Fitness" value={currentCtl} unit="CTL" size="sm" accent="#4a90d9" />
+      <MetricCard label="Fatigue" value={currentAtl} unit="ATL" size="sm" accent="#ff4d6d" />
+      <MetricCard label="Form" value={currentTsb} unit="TSB" size="sm" accent="#4caf50" />
+      <MetricCard label="FTP" value={currentFtp} unit="W" size="sm" />
+      <MetricCard label="Week TSS" value={thisWeekTss} size="sm" />
+    </div>
+
+    <section class="chart-section">
+      <h2>Performance Management</h2>
+      <PmcChart {pmcData} />
+    </section>
+
+    <div class="chart-grid">
+      <section class="chart-section">
+        <h2>Weekly Volume</h2>
+        <TrendChart
+          labels={weeklyData.map((w) => w.weekStart)}
+          barData={weeklyData.map((w) => Math.round(w.totalTss))}
+          barLabel="TSS"
+          barColor="#4a90d9"
+          lineData={weeklyData.map((w) => w.avgPower)}
+          lineLabel="Avg Power"
+          lineColor="#ff4d6d"
+          lineUnit="W"
+        />
+      </section>
+
+      <section class="chart-section">
+        <h2>HR Trends</h2>
+        <TrendChart
+          labels={weeklyData.map((w) => w.weekStart)}
+          barData={weeklyData.map((w) => w.sessionCount)}
+          barLabel="Sessions"
+          barColor="#64b5f6"
+          lineData={weeklyData.map((w) => w.avgHr)}
+          lineLabel="Avg HR"
+          lineColor="#f44336"
+          lineUnit="bpm"
+        />
+      </section>
+    </div>
+
+    {#if ftpPoints.length > 1}
+      <section class="chart-section">
+        <h2>FTP Progression</h2>
+        <TrendChart
+          labels={ftpPoints.map((p) => p.date)}
+          barData={ftpPoints.map((p) => p.ftp)}
+          barLabel="FTP"
+          barColor="#4caf50"
+          barUnit="W"
+        />
+      </section>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .page {
+    max-width: 1100px;
+  }
+
+  .page-header {
+    margin-bottom: var(--space-xl);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--text-2xl);
+    font-weight: 800;
+  }
+
+  h2 {
+    margin: 0 0 var(--space-md) 0;
+    font-size: var(--text-lg);
+    font-weight: 700;
+    color: var(--text-secondary);
+  }
+
+  .error {
+    margin-bottom: var(--space-lg);
+    padding: var(--space-md);
+    background: rgba(244, 67, 54, 0.08);
+    border: 1px solid rgba(244, 67, 54, 0.3);
+    border-radius: var(--radius-md);
+    color: var(--danger);
+    font-size: var(--text-base);
+  }
+
+  .empty {
+    color: var(--text-muted);
+    font-size: var(--text-base);
+    padding: var(--space-3xl) 0;
+    text-align: center;
+  }
+
+  .summary-cards {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: var(--space-md);
+    margin-bottom: var(--space-xl);
+  }
+
+  .chart-section {
+    margin-bottom: var(--space-xl);
+  }
+
+  .chart-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-xl);
+  }
+
+  .chart-grid .chart-section {
+    margin-bottom: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add dedicated Analytics page with Performance Management Chart (CTL/ATL/TSB) computed from existing session TSS data using exponential moving averages
- Add weekly trend charts (TSS volume + avg power, session count + avg HR) and FTP progression tracking
- Add summary metric cards for current Fitness, Fatigue, Form, FTP, and weekly TSS
- Pure frontend computation from `api.listSessions()` — no backend changes needed
- 18 new tests with hand-computed reference values covering PMC math, weekly bucketing, null handling, and FTP change-point extraction

## Test plan
- [x] `npx vitest run` — 53 tests passing (18 new)
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run build` — build succeeds
- [ ] Manual: navigate to Analytics page, verify charts render with session data
- [ ] Manual: verify empty state message when no sessions exist