### PR TITLE
Add adaptive zone control for HR and power zone rides

### DIFF
--- a/src-tauri/migrations/007_zone_config.sql
+++ b/src-tauri/migrations/007_zone_config.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN zone_config TEXT;

--- a/src-tauri/src/device/types.rs
+++ b/src-tauri/src/device/types.rs
@@ -2,6 +2,12 @@ use serde::{Deserialize, Serialize};
 use std::time::Instant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandSource {
+    ZoneControl,
+    Manual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Transport {
     Ble,
     AntPlus,
@@ -100,6 +106,11 @@ pub enum SensorReading {
         #[serde(default)]
         device_id: String,
     },
+    TrainerCommand {
+        target_watts: u16,
+        epoch_ms: u64,
+        source: CommandSource,
+    },
 }
 
 /// Detailed information about a connected device, including GATT services and characteristics.
@@ -156,6 +167,7 @@ impl SensorReading {
             SensorReading::HeartRate { epoch_ms, .. } => *epoch_ms,
             SensorReading::Cadence { epoch_ms, .. } => *epoch_ms,
             SensorReading::Speed { epoch_ms, .. } => *epoch_ms,
+            SensorReading::TrainerCommand { epoch_ms, .. } => *epoch_ms,
         }
     }
 
@@ -165,6 +177,7 @@ impl SensorReading {
             SensorReading::HeartRate { device_id, .. } => device_id,
             SensorReading::Cadence { device_id, .. } => device_id,
             SensorReading::Speed { device_id, .. } => device_id,
+            SensorReading::TrainerCommand { .. } => "",
         }
     }
 
@@ -174,6 +187,7 @@ impl SensorReading {
             SensorReading::HeartRate { .. } => DeviceType::HeartRate,
             SensorReading::Cadence { .. } => DeviceType::CadenceSpeed,
             SensorReading::Speed { .. } => DeviceType::CadenceSpeed,
+            SensorReading::TrainerCommand { .. } => DeviceType::FitnessTrainer,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use flexi_logger::{
 use log::Record;
 use session::manager::SessionManager;
 use session::storage::Storage;
+use session::zone_control::controller::ZoneController;
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
@@ -269,12 +270,15 @@ pub fn run() {
                     });
                 }
 
+                let zone_controller = Arc::new(tokio::sync::Mutex::new(ZoneController::new()));
+
                 AppState {
                     device_manager,
                     session_manager,
                     storage,
                     sensor_tx,
                     primary_devices,
+                    zone_controller,
                 }
             });
 
@@ -325,6 +329,14 @@ pub fn run() {
             commands::set_primary_device,
             commands::get_primary_devices,
             commands::unlink_devices,
+            commands::start_zone_control,
+            commands::stop_zone_control,
+            commands::pause_zone_control,
+            commands::resume_zone_control,
+            commands::get_zone_control_status,
+            commands::estimate_initial_power,
+            commands::save_zone_ride_config,
+            commands::get_zone_ride_config,
             commands::check_prerequisites,
             commands::fix_prerequisites,
         ])

--- a/src-tauri/src/session/fit_export.rs
+++ b/src-tauri/src/session/fit_export.rs
@@ -150,6 +150,7 @@ pub fn export_fit(summary: &SessionSummary, readings: &[SensorReading]) -> Resul
                 rec.extend_from_slice(&last_speed.to_le_bytes());
                 w.write_data(1, &rec);
             }
+            SensorReading::TrainerCommand { .. } => {}
         }
     }
 

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -158,6 +158,9 @@ impl SessionManager {
                 session.metrics.record_speed(*kmh);
                 session.last_speed = Some(now);
             }
+            SensorReading::TrainerCommand { .. } => {
+                // No metrics to record — logged to sensor_log below
+            }
         }
         session.sensor_log.push(reading);
     }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,3 +4,4 @@ pub mod manager;
 pub mod metrics;
 pub mod storage;
 pub mod types;
+pub mod zone_control;

--- a/src-tauri/src/session/zone_control/controller.rs
+++ b/src-tauri/src/session/zone_control/controller.rs
@@ -1,0 +1,579 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use log::info;
+use tokio::sync::{broadcast, watch, Mutex};
+use tokio::task::JoinHandle;
+
+use crate::device::manager::DeviceManager;
+use crate::device::types::{CommandSource, SensorReading};
+use crate::error::AppError;
+
+use super::pid::{adaptive_gains, HrSmoother, PidController};
+use super::types::{StopReason, ZoneControlStatus, ZoneMode, ZoneTarget};
+
+/// Maximum watts per tick adjustment (rate limiter, separate from PID output_limit)
+const HR_MAX_WATTS_PER_TICK: f64 = 10.0;
+/// Minimum commanded power (watts)
+const MIN_POWER: u16 = 50;
+/// Safety: reduce to this power when HR ceiling exceeded
+const SAFETY_POWER: u16 = 50;
+/// HR sensor lost thresholds (seconds)
+const HR_SENSOR_WARN_SECS: u64 = 15;
+const HR_SENSOR_STOP_SECS: u64 = 30;
+/// Power sensor lost threshold (seconds)
+const POWER_SENSOR_WARN_SECS: u64 = 15;
+/// Cadence zero threshold (seconds)
+const CADENCE_ZERO_SECS: u64 = 3;
+
+struct ControlLoopState {
+    active: bool,
+    target: Option<ZoneTarget>,
+    paused: bool,
+    commanded_power: u16,
+    time_in_zone_ms: u64,
+    started_at: Option<Instant>,
+    paused_accumulated_ms: u64,
+    pause_started: Option<Instant>,
+    phase: String,
+    safety_note: Option<String>,
+    stop_reason: Option<StopReason>,
+    last_power: Option<u16>,
+    last_hr: Option<u8>,
+    last_cadence: Option<f32>,
+    last_cadence_zero_since: Option<Instant>,
+    last_hr_seen: Option<Instant>,
+    last_power_seen: Option<Instant>,
+    /// FTP from user config, used for HR mode power clamping
+    ftp: Option<u16>,
+    /// Max HR from user config, used for HR ceiling safety
+    max_hr: Option<u8>,
+}
+
+impl ControlLoopState {
+    fn new() -> Self {
+        Self {
+            active: false,
+            target: None,
+            paused: false,
+            commanded_power: 0,
+            time_in_zone_ms: 0,
+            started_at: None,
+            paused_accumulated_ms: 0,
+            pause_started: None,
+            phase: "idle".to_string(),
+            safety_note: None,
+            stop_reason: None,
+            last_power: None,
+            last_hr: None,
+            last_cadence: None,
+            last_cadence_zero_since: None,
+            last_hr_seen: None,
+            last_power_seen: None,
+            ftp: None,
+            max_hr: None,
+        }
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        let Some(started) = self.started_at else {
+            return 0;
+        };
+        let total = started.elapsed().as_millis() as u64;
+        let paused = self.paused_accumulated_ms
+            + self
+                .pause_started
+                .map(|p| p.elapsed().as_millis() as u64)
+                .unwrap_or(0);
+        total.saturating_sub(paused)
+    }
+}
+
+pub struct ZoneController {
+    state: Arc<Mutex<ControlLoopState>>,
+    shutdown_tx: Option<watch::Sender<bool>>,
+    task_handle: Option<JoinHandle<()>>,
+}
+
+impl ZoneController {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ControlLoopState::new())),
+            shutdown_tx: None,
+            task_handle: None,
+        }
+    }
+
+    pub async fn start(
+        &mut self,
+        target: ZoneTarget,
+        device_manager: Arc<Mutex<DeviceManager>>,
+        sensor_tx: broadcast::Sender<SensorReading>,
+    ) -> Result<(), AppError> {
+        self.start_with_config(target, device_manager, sensor_tx, None, None, None)
+            .await
+    }
+
+    pub async fn start_with_config(
+        &mut self,
+        target: ZoneTarget,
+        device_manager: Arc<Mutex<DeviceManager>>,
+        sensor_tx: broadcast::Sender<SensorReading>,
+        ftp: Option<u16>,
+        max_hr: Option<u8>,
+        initial_power_estimate: Option<u16>,
+    ) -> Result<(), AppError> {
+        // Validate
+        if target.lower_bound >= target.upper_bound {
+            return Err(AppError::Session(
+                "Zone lower bound must be less than upper bound".into(),
+            ));
+        }
+
+        // Verify trainer connected
+        {
+            let dm = device_manager.lock().await;
+            if dm.connected_trainer_id().is_none() {
+                return Err(AppError::Session("No trainer connected".into()));
+            }
+        }
+
+        // Stop any existing control loop
+        self.stop_internal().await;
+
+        let midpoint = (target.lower_bound + target.upper_bound) / 2;
+        let initial_power = match target.mode {
+            ZoneMode::Power => midpoint,
+            ZoneMode::HeartRate => {
+                if let Some(estimate) = initial_power_estimate {
+                    // Historical model estimate, clamped to safe range
+                    let max = ftp.map(|f| (f as f64 * 1.2) as u16).unwrap_or(300);
+                    estimate.clamp(MIN_POWER, max)
+                } else {
+                    // Conservative start: 55% FTP if available, else 100W
+                    ftp.map(|f| (f as f64 * 0.55) as u16).unwrap_or(100)
+                }
+            }
+        };
+
+        {
+            let mut state = self.state.lock().await;
+            state.active = true;
+            state.target = Some(target.clone());
+            state.paused = false;
+            state.commanded_power = initial_power;
+            state.time_in_zone_ms = 0;
+            state.started_at = Some(Instant::now());
+            state.paused_accumulated_ms = 0;
+            state.pause_started = None;
+            state.phase = "ramping".to_string();
+            state.safety_note = None;
+            state.stop_reason = None;
+            state.last_power = None;
+            state.last_hr = None;
+            state.last_cadence = None;
+            state.last_cadence_zero_since = None;
+            state.last_hr_seen = None;
+            state.last_power_seen = None;
+            state.ftp = ftp;
+            state.max_hr = max_hr;
+        }
+
+        // Command trainer to initial power
+        {
+            let mut dm = device_manager.lock().await;
+            if let Some(trainer_id) = dm.connected_trainer_id() {
+                dm.set_target_power(&trainer_id, initial_power as i16)
+                    .await
+                    .ok();
+            }
+        }
+
+        // Log initial command
+        let _ = sensor_tx.send(SensorReading::TrainerCommand {
+            target_watts: initial_power,
+            epoch_ms: now_epoch_ms(),
+            source: CommandSource::ZoneControl,
+        });
+
+        info!(
+            "Zone control started: {:?} zone {} ({}-{} {}), initial {}W",
+            target.mode,
+            target.zone,
+            target.lower_bound,
+            target.upper_bound,
+            if target.mode == ZoneMode::Power {
+                "W"
+            } else {
+                "bpm"
+            },
+            initial_power
+        );
+
+        // Spawn control loop
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        self.shutdown_tx = Some(shutdown_tx);
+
+        let state = self.state.clone();
+        let sensor_rx = sensor_tx.subscribe();
+
+        let handle = tokio::spawn(control_loop(
+            state,
+            target,
+            device_manager,
+            sensor_tx,
+            sensor_rx,
+            shutdown_rx,
+        ));
+        self.task_handle = Some(handle);
+
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) -> Option<StopReason> {
+        self.stop_internal().await;
+        let mut state = self.state.lock().await;
+        let reason = state
+            .stop_reason
+            .take()
+            .unwrap_or(StopReason::UserStopped);
+        state.active = false;
+        state.phase = "idle".to_string();
+        info!("Zone control stopped: {:?}", reason);
+        Some(reason)
+    }
+
+    async fn stop_internal(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(true);
+        }
+        if let Some(handle) = self.task_handle.take() {
+            let _ = handle.await;
+        }
+    }
+
+    pub async fn pause(&self) {
+        let mut state = self.state.lock().await;
+        if state.active && !state.paused {
+            state.paused = true;
+            state.pause_started = Some(Instant::now());
+            info!("Zone control paused");
+        }
+    }
+
+    pub async fn resume(&self) {
+        let mut state = self.state.lock().await;
+        if state.active && state.paused {
+            if let Some(pause_start) = state.pause_started.take() {
+                state.paused_accumulated_ms += pause_start.elapsed().as_millis() as u64;
+            }
+            state.paused = false;
+            info!("Zone control resumed");
+        }
+    }
+
+    pub async fn status(&self) -> ZoneControlStatus {
+        let state = self.state.lock().await;
+        ZoneControlStatus {
+            active: state.active,
+            mode: state.target.as_ref().map(|t| t.mode),
+            target_zone: state.target.as_ref().map(|t| t.zone),
+            lower_bound: state.target.as_ref().map(|t| t.lower_bound),
+            upper_bound: state.target.as_ref().map(|t| t.upper_bound),
+            commanded_power: if state.active {
+                Some(state.commanded_power)
+            } else {
+                None
+            },
+            time_in_zone_secs: state.time_in_zone_ms / 1000,
+            elapsed_secs: state.elapsed_ms() / 1000,
+            duration_secs: state.target.as_ref().and_then(|t| t.duration_secs),
+            paused: state.paused,
+            phase: state.phase.clone(),
+            safety_note: state.safety_note.clone(),
+        }
+    }
+}
+
+fn now_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+async fn command_trainer(
+    device_manager: &Arc<Mutex<DeviceManager>>,
+    watts: u16,
+    sensor_tx: &broadcast::Sender<SensorReading>,
+) -> Result<(), AppError> {
+    let mut dm = device_manager.lock().await;
+    let trainer_id = dm
+        .connected_trainer_id()
+        .ok_or_else(|| AppError::Session("Trainer disconnected".into()))?;
+    dm.set_target_power(&trainer_id, watts as i16).await?;
+    drop(dm);
+
+    let _ = sensor_tx.send(SensorReading::TrainerCommand {
+        target_watts: watts,
+        epoch_ms: now_epoch_ms(),
+        source: CommandSource::ZoneControl,
+    });
+    Ok(())
+}
+
+async fn control_loop(
+    state: Arc<Mutex<ControlLoopState>>,
+    target: ZoneTarget,
+    device_manager: Arc<Mutex<DeviceManager>>,
+    sensor_tx: broadcast::Sender<SensorReading>,
+    mut sensor_rx: broadcast::Receiver<SensorReading>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let tick_interval = match target.mode {
+        ZoneMode::Power => tokio::time::Duration::from_secs(1),
+        ZoneMode::HeartRate => tokio::time::Duration::from_secs(5),
+    };
+    let mut tick = tokio::time::interval(tick_interval);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // HR mode PID and smoother (only used for HeartRate mode)
+    let mut pid = PidController::new(2.0, 0.1, 0.5);
+    let mut hr_smoother = HrSmoother::new(5);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                break;
+            }
+            result = sensor_rx.recv() => {
+                match result {
+                    Ok(reading) => {
+                        let mut s = state.lock().await;
+                        match &reading {
+                            SensorReading::Power { watts, .. } => {
+                                s.last_power = Some(*watts);
+                                s.last_power_seen = Some(Instant::now());
+                            }
+                            SensorReading::HeartRate { bpm, .. } => {
+                                s.last_hr = Some(*bpm);
+                                s.last_hr_seen = Some(Instant::now());
+                                hr_smoother.push(*bpm);
+                            }
+                            SensorReading::Cadence { rpm, .. } => {
+                                let now = Instant::now();
+                                if *rpm < 1.0 {
+                                    if s.last_cadence_zero_since.is_none() {
+                                        s.last_cadence_zero_since = Some(now);
+                                    }
+                                } else {
+                                    s.last_cadence_zero_since = None;
+                                }
+                                s.last_cadence = Some(*rpm);
+                            }
+                            _ => {}
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            _ = tick.tick() => {
+                let should_stop = process_tick(
+                    &state,
+                    &target,
+                    &device_manager,
+                    &sensor_tx,
+                    &mut pid,
+                    &hr_smoother,
+                ).await;
+                if should_stop {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn process_tick(
+    state: &Arc<Mutex<ControlLoopState>>,
+    target: &ZoneTarget,
+    device_manager: &Arc<Mutex<DeviceManager>>,
+    sensor_tx: &broadcast::Sender<SensorReading>,
+    pid: &mut PidController,
+    hr_smoother: &HrSmoother,
+) -> bool {
+    let mut s = state.lock().await;
+
+    if !s.active || s.paused {
+        return false;
+    }
+
+    // === Safety: cadence zero for >CADENCE_ZERO_SECS → command 0W ===
+    if let Some(zero_since) = s.last_cadence_zero_since {
+        if zero_since.elapsed().as_secs() >= CADENCE_ZERO_SECS {
+            if s.commanded_power != 0 {
+                s.commanded_power = 0;
+                s.safety_note = Some("Cadence zero — power reduced".to_string());
+                drop(s);
+                if command_trainer(device_manager, 0, sensor_tx).await.is_err() {
+                    let mut s = state.lock().await;
+                    s.stop_reason = Some(StopReason::TrainerDisconnected);
+                    s.active = false;
+                    return true;
+                }
+                return false;
+            }
+            return false;
+        }
+    }
+
+    // === Safety: HR ceiling (HR mode) ===
+    if target.mode == ZoneMode::HeartRate {
+        if let Some(max_hr) = s.max_hr {
+            if let Some(hr) = s.last_hr {
+                if hr > max_hr {
+                    s.commanded_power = SAFETY_POWER;
+                    s.safety_note = Some("HR ceiling exceeded".to_string());
+                    s.phase = "adjusting".to_string();
+                    drop(s);
+                    if command_trainer(device_manager, SAFETY_POWER, sensor_tx)
+                        .await
+                        .is_err()
+                    {
+                        let mut s = state.lock().await;
+                        s.stop_reason = Some(StopReason::TrainerDisconnected);
+                        s.active = false;
+                        return true;
+                    }
+                    return false;
+                }
+            }
+        }
+
+        // === Safety: HR sensor lost (HR mode) ===
+        let hr_lost_secs = s
+            .last_hr_seen
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(u64::MAX);
+        if hr_lost_secs >= HR_SENSOR_STOP_SECS {
+            s.stop_reason = Some(StopReason::SensorLost);
+            s.safety_note = Some("HR sensor lost".to_string());
+            s.active = false;
+            return true;
+        } else if hr_lost_secs >= HR_SENSOR_WARN_SECS {
+            s.safety_note = Some("HR sensor not responding — holding power".to_string());
+            // Hold current power, don't adjust
+            return false;
+        }
+    }
+
+    // === Safety: Power sensor lost (power mode) ===
+    if target.mode == ZoneMode::Power {
+        let power_lost_secs = s
+            .last_power_seen
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(u64::MAX);
+        if power_lost_secs >= POWER_SENSOR_WARN_SECS {
+            s.safety_note = Some("Power sensor not responding".to_string());
+            // Continue — trainer ERG still works
+        }
+    }
+
+    // === Check duration expiry ===
+    if let Some(duration) = target.duration_secs {
+        if s.elapsed_ms() / 1000 >= duration {
+            s.stop_reason = Some(StopReason::DurationComplete);
+            s.active = false;
+            info!("Zone control: duration complete");
+            return true;
+        }
+    }
+
+    // === Mode-specific tick ===
+    match target.mode {
+        ZoneMode::Power => {
+            process_power_tick(&mut s, target);
+        }
+        ZoneMode::HeartRate => {
+            let new_power = process_hr_tick(&mut s, target, pid, hr_smoother);
+            if let Some(watts) = new_power {
+                s.commanded_power = watts;
+                drop(s);
+                if command_trainer(device_manager, watts, sensor_tx)
+                    .await
+                    .is_err()
+                {
+                    let mut s = state.lock().await;
+                    s.stop_reason = Some(StopReason::TrainerDisconnected);
+                    s.active = false;
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn process_power_tick(s: &mut ControlLoopState, target: &ZoneTarget) {
+    if let Some(power) = s.last_power {
+        let in_zone = power >= target.lower_bound && power <= target.upper_bound;
+        if in_zone {
+            s.time_in_zone_ms += 1000; // 1s tick
+            s.phase = "in_zone".to_string();
+            s.safety_note = None;
+        } else {
+            s.phase = "adjusting".to_string();
+        }
+    } else {
+        s.phase = "ramping".to_string();
+    }
+}
+
+/// HR mode tick: uses PID controller with adaptive gains to adjust power.
+/// Returns Some(new_watts) if power should be changed, None to hold.
+fn process_hr_tick(
+    s: &mut ControlLoopState,
+    target: &ZoneTarget,
+    pid: &mut PidController,
+    hr_smoother: &HrSmoother,
+) -> Option<u16> {
+    let smoothed_hr = hr_smoother.smoothed()?;
+    let target_hr = ((target.lower_bound + target.upper_bound) / 2) as f64;
+    let error = target_hr - smoothed_hr as f64;
+
+    // Track time in zone
+    let in_zone =
+        smoothed_hr as u16 >= target.lower_bound && smoothed_hr as u16 <= target.upper_bound;
+    if in_zone {
+        s.time_in_zone_ms += 5000; // 5s tick
+        s.phase = "in_zone".to_string();
+        s.safety_note = None;
+    } else {
+        s.phase = "adjusting".to_string();
+    }
+
+    // Adaptive gains based on distance from target
+    let (kp, ki, kd) = adaptive_gains(error.abs());
+    pid.set_gains(kp, ki, kd);
+
+    let dt_secs = 5.0; // HR mode tick interval
+    let watts_adjustment = pid.update(error, dt_secs);
+
+    // Rate limit: max ±HR_MAX_WATTS_PER_TICK per tick
+    let clamped_adjustment =
+        watts_adjustment.clamp(-HR_MAX_WATTS_PER_TICK, HR_MAX_WATTS_PER_TICK);
+
+    let new_power_f = s.commanded_power as f64 + clamped_adjustment;
+
+    // Clamp to [MIN_POWER, FTP×1.5]
+    let max_power = s.ftp.map(|f| (f as f64 * 1.5) as u16).unwrap_or(400);
+    let new_power = (new_power_f as u16).clamp(MIN_POWER, max_power);
+
+    if new_power != s.commanded_power {
+        Some(new_power)
+    } else {
+        None
+    }
+}

--- a/src-tauri/src/session/zone_control/mod.rs
+++ b/src-tauri/src/session/zone_control/mod.rs
@@ -1,0 +1,3 @@
+pub mod controller;
+pub mod pid;
+pub mod types;

--- a/src-tauri/src/session/zone_control/pid.rs
+++ b/src-tauri/src/session/zone_control/pid.rs
@@ -1,0 +1,297 @@
+pub struct PidController {
+    kp: f64,
+    ki: f64,
+    kd: f64,
+    integral: f64,
+    prev_error: Option<f64>,
+    integral_limit: f64,
+    output_limit: f64,
+}
+
+impl PidController {
+    pub fn new(kp: f64, ki: f64, kd: f64) -> Self {
+        Self::with_limits(kp, ki, kd, 200.0, 30.0)
+    }
+
+    pub fn with_limits(kp: f64, ki: f64, kd: f64, integral_limit: f64, output_limit: f64) -> Self {
+        Self {
+            kp,
+            ki,
+            kd,
+            integral: 0.0,
+            prev_error: None,
+            integral_limit,
+            output_limit,
+        }
+    }
+
+    pub fn update(&mut self, error: f64, dt_secs: f64) -> f64 {
+        // Proportional
+        let p = self.kp * error;
+
+        // Integral with anti-windup
+        self.integral += error * dt_secs;
+        self.integral = self.integral.clamp(-self.integral_limit, self.integral_limit);
+        let i = self.ki * self.integral;
+
+        // Derivative
+        let d = match self.prev_error {
+            Some(prev) => self.kd * (error - prev) / dt_secs,
+            None => 0.0,
+        };
+        self.prev_error = Some(error);
+
+        let output = p + i + d;
+        output.clamp(-self.output_limit, self.output_limit)
+    }
+
+    pub fn reset(&mut self) {
+        self.integral = 0.0;
+        self.prev_error = None;
+    }
+
+    pub fn set_gains(&mut self, kp: f64, ki: f64, kd: f64) {
+        self.kp = kp;
+        self.ki = ki;
+        self.kd = kd;
+    }
+}
+
+use std::collections::VecDeque;
+
+pub struct HrSmoother {
+    buffer: VecDeque<u8>,
+    window_size: usize,
+}
+
+impl HrSmoother {
+    pub fn new(window_size: usize) -> Self {
+        Self {
+            buffer: VecDeque::with_capacity(window_size),
+            window_size,
+        }
+    }
+
+    pub fn push(&mut self, bpm: u8) {
+        if self.buffer.len() >= self.window_size {
+            self.buffer.pop_front();
+        }
+        self.buffer.push_back(bpm);
+    }
+
+    pub fn smoothed(&self) -> Option<u8> {
+        if self.buffer.is_empty() {
+            return None;
+        }
+        let mut sorted: Vec<u8> = self.buffer.iter().copied().collect();
+        sorted.sort_unstable();
+        Some(sorted[sorted.len() / 2])
+    }
+}
+
+/// Returns (kp, ki, kd) tuned for distance from target.
+pub fn adaptive_gains(error_abs: f64) -> (f64, f64, f64) {
+    if error_abs > 15.0 {
+        // Far from target — aggressive ramp
+        (3.0, 0.15, 0.8)
+    } else if error_abs > 5.0 {
+        // Getting close — moderate
+        (2.0, 0.10, 0.5)
+    } else {
+        // In/near zone — gentle maintenance
+        (1.0, 0.05, 0.3)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_approx(actual: f64, expected: f64, epsilon: f64, msg: &str) {
+        assert!(
+            (actual - expected).abs() <= epsilon,
+            "{msg}: expected {expected} ± {epsilon}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn proportional_only_positive_error() {
+        // P-only: error=10, kp=2.0 → output=20.0
+        let mut pid = PidController::with_limits(2.0, 0.0, 0.0, 200.0, 100.0);
+        let out = pid.update(10.0, 1.0);
+        assert_approx(out, 20.0, 0.01, "P-only positive error");
+    }
+
+    #[test]
+    fn proportional_only_negative_error() {
+        // P-only: error=-5, kp=2.0 → output=-10.0
+        let mut pid = PidController::with_limits(2.0, 0.0, 0.0, 200.0, 100.0);
+        let out = pid.update(-5.0, 1.0);
+        assert_approx(out, -10.0, 0.01, "P-only negative error");
+    }
+
+    #[test]
+    fn integral_accumulates_over_ticks() {
+        // I-only: error=5, ki=0.1, dt=5 → integral=25, output=2.5
+        let mut pid = PidController::with_limits(0.0, 0.1, 0.0, 200.0, 100.0);
+        let out1 = pid.update(5.0, 5.0);
+        assert_approx(out1, 2.5, 0.01, "I-only first tick");
+
+        // Second tick: integral=50, output=5.0
+        let out2 = pid.update(5.0, 5.0);
+        assert_approx(out2, 5.0, 0.01, "I-only second tick");
+    }
+
+    #[test]
+    fn anti_windup_clamps_integral() {
+        // ki=1.0, error=1000, dt=1 → integral would be 1000 but clamped to 200
+        let mut pid = PidController::with_limits(0.0, 1.0, 0.0, 200.0, 1000.0);
+        let out = pid.update(1000.0, 1.0);
+        // integral clamped to 200, output = 1.0 * 200 = 200
+        assert_approx(out, 200.0, 0.01, "anti-windup clamps integral");
+    }
+
+    #[test]
+    fn derivative_responds_to_error_change() {
+        // D-only: first tick error=10, second tick error=5, kd=1.0, dt=5
+        // derivative = (5 - 10) / 5 = -1.0, output = 1.0 * -1.0 = -1.0
+        let mut pid = PidController::with_limits(0.0, 0.0, 1.0, 200.0, 100.0);
+        let out1 = pid.update(10.0, 5.0);
+        assert_approx(out1, 0.0, 0.01, "D-only first tick (no prev)");
+
+        let out2 = pid.update(5.0, 5.0);
+        assert_approx(out2, -1.0, 0.01, "D-only second tick");
+    }
+
+    #[test]
+    fn output_clamp_limits_extreme_adjustments() {
+        // Large error with output_limit=30 → clamped to 30
+        let mut pid = PidController::with_limits(10.0, 0.0, 0.0, 200.0, 30.0);
+        let out = pid.update(100.0, 1.0);
+        assert_approx(out, 30.0, 0.01, "output clamped to 30");
+
+        // Negative extreme
+        let out_neg = pid.update(-100.0, 1.0);
+        assert_approx(out_neg, -30.0, 0.01, "output clamped to -30");
+    }
+
+    #[test]
+    fn full_pid_first_tick() {
+        // kp=2, ki=0.1, kd=0.5, error=10, dt=5
+        // P = 2 * 10 = 20
+        // I = 0.1 * (10 * 5) = 0.1 * 50 = 5
+        // D = 0 (first tick, no prev_error)
+        // total = 25, output_limit=30 → output=25
+        let mut pid = PidController::with_limits(2.0, 0.1, 0.5, 200.0, 30.0);
+        let out = pid.update(10.0, 5.0);
+        assert_approx(out, 25.0, 0.01, "full PID first tick");
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut pid = PidController::with_limits(0.0, 1.0, 1.0, 200.0, 100.0);
+        pid.update(10.0, 1.0);
+        pid.update(20.0, 1.0);
+
+        pid.reset();
+
+        // After reset, integral should be 0 and no prev_error
+        // I-only: error=5, dt=1 → integral=5, output=5
+        let out = pid.update(5.0, 1.0);
+        assert_approx(out, 5.0, 0.01, "after reset, integral starts fresh");
+    }
+
+    // --- HrSmoother tests ---
+
+    #[test]
+    fn smoother_single_reading_returns_that_reading() {
+        let mut s = HrSmoother::new(5);
+        s.push(140);
+        assert_eq!(s.smoothed(), Some(140));
+    }
+
+    #[test]
+    fn smoother_median_rejects_spike() {
+        // [100, 200, 150] sorted = [100, 150, 200], median = 150
+        let mut s = HrSmoother::new(5);
+        s.push(100);
+        s.push(200);
+        s.push(150);
+        assert_eq!(s.smoothed(), Some(150));
+    }
+
+    #[test]
+    fn smoother_window_overflow_drops_oldest() {
+        let mut s = HrSmoother::new(3);
+        s.push(100);
+        s.push(110);
+        s.push(120);
+        // Window: [100, 110, 120], median = 110
+        assert_eq!(s.smoothed(), Some(110));
+
+        s.push(200);
+        // Window: [110, 120, 200], median = 120
+        assert_eq!(s.smoothed(), Some(120));
+    }
+
+    #[test]
+    fn smoother_empty_returns_none() {
+        let s = HrSmoother::new(5);
+        assert_eq!(s.smoothed(), None);
+    }
+
+    // --- adaptive_gains tests ---
+
+    #[test]
+    fn adaptive_gains_far_from_target() {
+        // error=20 → aggressive gains
+        let (kp, ki, kd) = adaptive_gains(20.0);
+        assert_approx(kp, 3.0, 0.01, "far kp");
+        assert_approx(ki, 0.15, 0.01, "far ki");
+        assert_approx(kd, 0.8, 0.01, "far kd");
+    }
+
+    #[test]
+    fn adaptive_gains_moderate_distance() {
+        // error=10 → moderate gains
+        let (kp, ki, kd) = adaptive_gains(10.0);
+        assert_approx(kp, 2.0, 0.01, "moderate kp");
+        assert_approx(ki, 0.10, 0.01, "moderate ki");
+        assert_approx(kd, 0.5, 0.01, "moderate kd");
+    }
+
+    #[test]
+    fn adaptive_gains_near_target() {
+        // error=3 → gentle gains
+        let (kp, ki, kd) = adaptive_gains(3.0);
+        assert_approx(kp, 1.0, 0.01, "gentle kp");
+        assert_approx(ki, 0.05, 0.01, "gentle ki");
+        assert_approx(kd, 0.3, 0.01, "gentle kd");
+    }
+
+    #[test]
+    fn adaptive_gains_zero_error() {
+        let (kp, ki, kd) = adaptive_gains(0.0);
+        assert_approx(kp, 1.0, 0.01, "zero kp");
+        assert_approx(ki, 0.05, 0.01, "zero ki");
+        assert_approx(kd, 0.3, 0.01, "zero kd");
+    }
+
+    #[test]
+    fn adaptive_gains_boundary_15() {
+        // error=15 exactly → moderate (> check, not >=)
+        let (kp, ki, kd) = adaptive_gains(15.0);
+        assert_approx(kp, 2.0, 0.01, "boundary 15 kp");
+        assert_approx(ki, 0.10, 0.01, "boundary 15 ki");
+        assert_approx(kd, 0.5, 0.01, "boundary 15 kd");
+    }
+
+    #[test]
+    fn adaptive_gains_boundary_5() {
+        // error=5 exactly → gentle (> check, not >=)
+        let (kp, ki, kd) = adaptive_gains(5.0);
+        assert_approx(kp, 1.0, 0.01, "boundary 5 kp");
+        assert_approx(ki, 0.05, 0.01, "boundary 5 ki");
+        assert_approx(kd, 0.3, 0.01, "boundary 5 kd");
+    }
+}

--- a/src-tauri/src/session/zone_control/types.rs
+++ b/src-tauri/src/session/zone_control/types.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ZoneMode {
+    Power,
+    HeartRate,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneTarget {
+    pub mode: ZoneMode,
+    pub zone: u8,
+    pub lower_bound: u16,
+    pub upper_bound: u16,
+    pub duration_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneControlStatus {
+    pub active: bool,
+    pub mode: Option<ZoneMode>,
+    pub target_zone: Option<u8>,
+    pub lower_bound: Option<u16>,
+    pub upper_bound: Option<u16>,
+    pub commanded_power: Option<u16>,
+    pub time_in_zone_secs: u64,
+    pub elapsed_secs: u64,
+    pub duration_secs: Option<u64>,
+    pub paused: bool,
+    pub phase: String,
+    pub safety_note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StopReason {
+    UserStopped,
+    DurationComplete,
+    SafetyStop,
+    TrainerDisconnected,
+    SensorLost,
+}

--- a/src/lib/components/ZoneRideAnalysis.svelte
+++ b/src/lib/components/ZoneRideAnalysis.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+  import type { ZoneRideConfig } from '$lib/tauri';
+  import { computeDecoupling, computeTimeInZone, computeTimeToZone } from '$lib/utils/zoneAnalysis';
+  import { formatDuration } from '$lib/utils/format';
+
+  let {
+    config,
+    timeseries,
+  }: {
+    config: ZoneRideConfig;
+    timeseries: { power: number | null; heart_rate: number | null }[];
+  } = $props();
+
+  let modeLabel = $derived(config.mode === 'HeartRate' ? 'HR' : 'Power');
+  let unit = $derived(config.mode === 'HeartRate' ? 'bpm' : 'W');
+  let zoneLabel = $derived(config.zone > 0 ? `Z${config.zone}` : 'Custom');
+
+  // Build value series from the appropriate channel
+  let valueSeries = $derived.by(() => {
+    return timeseries.map((pt) => ({
+      value: config.mode === 'HeartRate' ? (pt.heart_rate as number | null) : (pt.power as number | null),
+    }));
+  });
+
+  let timeInZone = $derived(
+    computeTimeInZone(valueSeries, config.lower_bound, config.upper_bound, 1),
+  );
+
+  let timeToZone = $derived(
+    computeTimeToZone(valueSeries, config.lower_bound, config.upper_bound, 1),
+  );
+
+  let decoupling = $derived(computeDecoupling(timeseries));
+
+  let totalTracked = $derived(timeInZone.inZoneSecs + timeInZone.belowSecs + timeInZone.aboveSecs);
+  let inZonePct = $derived(totalTracked > 0 ? (timeInZone.inZoneSecs / totalTracked) * 100 : 0);
+  let belowPct = $derived(totalTracked > 0 ? (timeInZone.belowSecs / totalTracked) * 100 : 0);
+  let abovePct = $derived(totalTracked > 0 ? (timeInZone.aboveSecs / totalTracked) * 100 : 0);
+
+  let decouplingLabel = $derived.by(() => {
+    if (decoupling == null) return null;
+    const abs = Math.abs(decoupling);
+    if (abs < 3) return 'Excellent';
+    if (abs < 5) return 'Good';
+    if (abs < 8) return 'Moderate drift';
+    return 'Significant drift';
+  });
+
+  let decouplingColor = $derived.by(() => {
+    if (decoupling == null) return 'var(--text-muted)';
+    const abs = Math.abs(decoupling);
+    if (abs < 5) return 'var(--success)';
+    if (abs < 8) return 'var(--warning)';
+    return 'var(--danger)';
+  });
+</script>
+
+<section class="zone-analysis">
+  <h2>Zone Ride Analysis</h2>
+
+  <div class="zone-summary">
+    <div class="summary-badge">
+      <span class="badge-mode">{zoneLabel} {modeLabel}</span>
+      <span class="badge-range">{config.lower_bound}&ndash;{config.upper_bound} {unit}</span>
+    </div>
+
+    <div class="summary-stats">
+      <div class="stat">
+        <span class="stat-label">Time in Zone</span>
+        <span class="stat-value">{formatDuration(config.time_in_zone_secs)}</span>
+        <span class="stat-sub">{inZonePct.toFixed(0)}%</span>
+      </div>
+
+      {#if timeToZone != null}
+        <div class="stat">
+          <span class="stat-label">Time to Zone</span>
+          <span class="stat-value">{formatDuration(timeToZone)}</span>
+        </div>
+      {/if}
+
+      {#if config.duration_secs != null}
+        <div class="stat">
+          <span class="stat-label">Target Duration</span>
+          <span class="stat-value">{formatDuration(config.duration_secs)}</span>
+        </div>
+      {/if}
+
+      {#if decoupling != null}
+        <div class="stat">
+          <span class="stat-label">Decoupling</span>
+          <span class="stat-value" style="color: {decouplingColor}">
+            {decoupling.toFixed(1)}%
+          </span>
+          <span class="stat-sub" style="color: {decouplingColor}">{decouplingLabel}</span>
+        </div>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Time in zone bar -->
+  <div class="zone-bar-wrap">
+    <div class="zone-bar">
+      {#if belowPct > 0}
+        <div class="bar-segment below" style="width: {belowPct}%" title="Below: {formatDuration(timeInZone.belowSecs)}"></div>
+      {/if}
+      {#if inZonePct > 0}
+        <div class="bar-segment in-zone" style="width: {inZonePct}%" title="In zone: {formatDuration(timeInZone.inZoneSecs)}"></div>
+      {/if}
+      {#if abovePct > 0}
+        <div class="bar-segment above" style="width: {abovePct}%" title="Above: {formatDuration(timeInZone.aboveSecs)}"></div>
+      {/if}
+    </div>
+    <div class="bar-legend">
+      <span class="legend-item"><span class="dot below"></span> Below</span>
+      <span class="legend-item"><span class="dot in-zone"></span> In Zone</span>
+      <span class="legend-item"><span class="dot above"></span> Above</span>
+    </div>
+  </div>
+</section>
+
+<style>
+  .zone-analysis {
+    margin-bottom: var(--space-xl);
+  }
+
+  h2 {
+    margin: 0 0 var(--space-md);
+    font-size: var(--text-base);
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .zone-summary {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-lg);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-md);
+  }
+
+  .summary-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--accent-soft);
+    border-radius: var(--radius-md);
+    flex-shrink: 0;
+  }
+
+  .badge-mode {
+    font-size: var(--text-sm);
+    font-weight: 700;
+    color: var(--accent);
+    letter-spacing: 0.04em;
+  }
+
+  .badge-range {
+    font-family: var(--font-data);
+    font-size: var(--text-xs);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+  }
+
+  .summary-stats {
+    display: flex;
+    gap: var(--space-lg);
+    flex-wrap: wrap;
+  }
+
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .stat-label {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .stat-value {
+    font-family: var(--font-data);
+    font-size: var(--text-lg);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+  }
+
+  .stat-sub {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  /* Zone bar */
+  .zone-bar-wrap {
+    margin-top: var(--space-sm);
+  }
+
+  .zone-bar {
+    display: flex;
+    height: 12px;
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    background: var(--bg-body);
+  }
+
+  .bar-segment {
+    transition: width 300ms ease;
+    min-width: 2px;
+  }
+
+  .bar-segment.below {
+    background: var(--info);
+  }
+
+  .bar-segment.in-zone {
+    background: var(--success);
+  }
+
+  .bar-segment.above {
+    background: var(--danger);
+  }
+
+  .bar-legend {
+    display: flex;
+    gap: var(--space-md);
+    margin-top: var(--space-xs);
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .dot.below {
+    background: var(--info);
+  }
+
+  .dot.in-zone {
+    background: var(--success);
+  }
+
+  .dot.above {
+    background: var(--danger);
+  }
+</style>

--- a/src/lib/components/ZoneRideBuilder.svelte
+++ b/src/lib/components/ZoneRideBuilder.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import type { SessionConfig, ZoneTarget, ZoneMode } from '$lib/tauri';
+  import { resolveZoneBounds } from '$lib/stores/zoneRide';
+
+  let {
+    config,
+    onStart,
+    trainerConnected = false,
+  }: {
+    config: SessionConfig;
+    onStart: (target: ZoneTarget) => void;
+    trainerConnected?: boolean;
+  } = $props();
+
+  let mode: ZoneMode = $state('Power');
+  let selectedZone = $state(3);
+  let customLower = $state(150);
+  let customUpper = $state(200);
+  let durationMin = $state(20);
+  let useCustom = $state(false);
+
+  const powerZoneCount = 7;
+  const hrZoneCount = 5;
+
+  let resolved = $derived.by(() => {
+    if (useCustom) return { lower: customLower, upper: customUpper };
+    return resolveZoneBounds(mode, selectedZone, config);
+  });
+
+  let zoneCount = $derived(mode === 'Power' ? powerZoneCount : hrZoneCount);
+  let unit = $derived(mode === 'Power' ? 'W' : 'bpm');
+
+  function switchMode(m: ZoneMode) {
+    mode = m;
+    selectedZone = 3;
+    useCustom = false;
+  }
+
+  function selectZone(z: number) {
+    selectedZone = z;
+    useCustom = false;
+  }
+
+  function handleStart() {
+    onStart({
+      mode,
+      zone: useCustom ? 0 : selectedZone,
+      lower_bound: resolved.lower,
+      upper_bound: resolved.upper,
+      duration_secs: durationMin > 0 ? durationMin * 60 : null,
+    });
+  }
+</script>
+
+<div class="zone-builder">
+  <div class="builder-row">
+    <div class="mode-tabs">
+      <button class="tab" class:active={mode === 'Power'} onclick={() => switchMode('Power')}>Power</button>
+      <button class="tab" class:active={mode === 'HeartRate'} onclick={() => switchMode('HeartRate')}>HR</button>
+    </div>
+
+    <div class="zone-btns">
+      {#each Array.from({ length: zoneCount }, (_, i) => i + 1) as z}
+        <button
+          class="zone-btn"
+          class:active={!useCustom && selectedZone === z}
+          onclick={() => selectZone(z)}
+        >Z{z}</button>
+      {/each}
+      <button class="zone-btn" class:active={useCustom} onclick={() => { useCustom = true; }}>Custom</button>
+    </div>
+  </div>
+
+  <div class="builder-row">
+    {#if useCustom}
+      <div class="custom-inputs">
+        <label class="custom-field">
+          <span class="field-label">Min</span>
+          <input type="number" bind:value={customLower} min="0" max="500" class="num-input" />
+          <span class="field-unit">{unit}</span>
+        </label>
+        <span class="range-sep">&ndash;</span>
+        <label class="custom-field">
+          <span class="field-label">Max</span>
+          <input type="number" bind:value={customUpper} min="0" max="500" class="num-input" />
+          <span class="field-unit">{unit}</span>
+        </label>
+      </div>
+    {:else}
+      <div class="resolved-bounds">
+        <span class="bounds-value">{resolved.lower}&ndash;{resolved.upper}</span>
+        <span class="bounds-unit">{unit}</span>
+      </div>
+    {/if}
+
+    <div class="duration-field">
+      <input type="number" bind:value={durationMin} min="0" max="240" class="num-input dur" />
+      <span class="field-unit">min</span>
+    </div>
+
+    <button
+      class="btn-start-zone"
+      disabled={!trainerConnected || resolved.lower >= resolved.upper}
+      onclick={handleStart}
+    >
+      Start Zone
+    </button>
+  </div>
+</div>
+
+<style>
+  .zone-builder {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-sm) 0;
+  }
+
+  .builder-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+  }
+
+  .mode-tabs {
+    display: flex;
+    gap: 2px;
+    background: var(--bg-body);
+    border-radius: var(--radius-md);
+    padding: 2px;
+    flex-shrink: 0;
+  }
+
+  .tab {
+    padding: var(--space-xs) var(--space-md);
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: all var(--transition-fast);
+    letter-spacing: 0.04em;
+  }
+
+  .tab:hover {
+    color: var(--text-secondary);
+  }
+
+  .tab.active {
+    background: var(--bg-elevated);
+    color: var(--accent);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .zone-btns {
+    display: flex;
+    gap: 3px;
+  }
+
+  .zone-btn {
+    padding: var(--space-xs) var(--space-sm);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-body);
+    color: var(--text-secondary);
+    font-family: var(--font-data);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    cursor: pointer;
+    min-width: 32px;
+    text-align: center;
+    transition: all var(--transition-fast);
+  }
+
+  .zone-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .zone-btn.active {
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+
+  .resolved-bounds {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-xs);
+  }
+
+  .bounds-value {
+    font-family: var(--font-data);
+    font-size: var(--text-lg);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+  }
+
+  .bounds-unit {
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .custom-inputs {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+
+  .custom-field {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .field-label {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .field-unit {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .range-sep {
+    color: var(--text-muted);
+    font-weight: 600;
+  }
+
+  .num-input {
+    width: 56px;
+    padding: var(--space-xs) var(--space-sm);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-body);
+    color: var(--text-primary);
+    font-family: var(--font-data);
+    font-size: var(--text-sm);
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+  }
+
+  .num-input:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .num-input.dur {
+    width: 48px;
+  }
+
+  .duration-field {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .btn-start-zone {
+    padding: var(--space-sm) var(--space-lg);
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--accent);
+    color: white;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    white-space: nowrap;
+  }
+
+  .btn-start-zone:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(var(--accent-rgb, 33, 150, 243), 0.3);
+  }
+
+  .btn-start-zone:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/lib/components/ZoneRideStatus.svelte
+++ b/src/lib/components/ZoneRideStatus.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import { zoneStatus } from '$lib/stores/zoneRide';
+  import { formatDuration } from '$lib/utils/format';
+
+  let {
+    onStop,
+  }: {
+    onStop: () => void;
+  } = $props();
+
+  let phaseColor = $derived.by(() => {
+    const phase = $zoneStatus?.phase;
+    if (phase === 'in_zone') return 'var(--success)';
+    if (phase === 'ramping' || phase === 'adjusting') return 'var(--warning)';
+    return 'var(--text-muted)';
+  });
+
+  let modeLabel = $derived.by(() => {
+    if (!$zoneStatus) return '';
+    const z = $zoneStatus.target_zone;
+    const m = $zoneStatus.mode === 'HeartRate' ? 'HR' : 'PWR';
+    return z ? `Z${z} ${m}` : `${m}`;
+  });
+
+  let remaining = $derived.by(() => {
+    if (!$zoneStatus?.duration_secs) return null;
+    const left = $zoneStatus.duration_secs - $zoneStatus.elapsed_secs;
+    return Math.max(0, left);
+  });
+</script>
+
+{#if $zoneStatus?.active}
+  <div class="zone-status">
+    <span class="zone-badge">{modeLabel}</span>
+
+    {#if $zoneStatus.lower_bound != null && $zoneStatus.upper_bound != null}
+      <span class="target-range">
+        {$zoneStatus.lower_bound}&ndash;{$zoneStatus.upper_bound}
+        <span class="range-unit">{$zoneStatus.mode === 'HeartRate' ? 'bpm' : 'W'}</span>
+      </span>
+    {/if}
+
+    <span class="phase-dot" style="background: {phaseColor}"></span>
+    <span class="phase-label">{$zoneStatus.phase}</span>
+
+    <span class="status-divider"></span>
+
+    <span class="time-label">
+      In zone: <strong>{formatDuration($zoneStatus.time_in_zone_secs)}</strong>
+    </span>
+
+    {#if remaining != null}
+      <span class="time-label">
+        Left: <strong>{formatDuration(remaining)}</strong>
+      </span>
+    {/if}
+
+    {#if $zoneStatus.commanded_power != null}
+      <span class="cmd-power">{$zoneStatus.commanded_power}<span class="cmd-unit">W</span></span>
+    {/if}
+
+    {#if $zoneStatus.safety_note}
+      <span class="safety-note">{$zoneStatus.safety_note}</span>
+    {/if}
+
+    <button class="btn-stop-zone" onclick={onStop}>Stop</button>
+  </div>
+{/if}
+
+<style>
+  .zone-status {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+  }
+
+  .zone-badge {
+    padding: var(--space-xs) var(--space-sm);
+    border-radius: var(--radius-sm);
+    background: var(--accent);
+    color: white;
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+  }
+
+  .target-range {
+    font-family: var(--font-data);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+  }
+
+  .range-unit {
+    font-size: 0.8em;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  .phase-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .phase-label {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    text-transform: capitalize;
+  }
+
+  .status-divider {
+    width: 1px;
+    height: 18px;
+    background: var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .time-label {
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+  }
+
+  .time-label strong {
+    font-family: var(--font-data);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+  }
+
+  .cmd-power {
+    font-family: var(--font-data);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--info);
+  }
+
+  .cmd-unit {
+    font-size: 0.7em;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-left: 1px;
+  }
+
+  .safety-note {
+    font-size: var(--text-xs);
+    color: var(--warning);
+    font-weight: 500;
+  }
+
+  .btn-stop-zone {
+    padding: var(--space-xs) var(--space-md);
+    border: 1px solid var(--danger);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--danger);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    white-space: nowrap;
+  }
+
+  .btn-stop-zone:hover {
+    background: var(--danger);
+    color: white;
+  }
+</style>

--- a/src/lib/stores/zoneRide.ts
+++ b/src/lib/stores/zoneRide.ts
@@ -1,0 +1,74 @@
+import { writable, derived } from 'svelte/store';
+import { api } from '$lib/tauri';
+import type { ZoneControlStatus, ZoneTarget, ZoneMode, SessionConfig } from '$lib/tauri';
+
+export const zoneStatus = writable<ZoneControlStatus | null>(null);
+export const zoneActive = derived(zoneStatus, ($s) => $s?.active ?? false);
+
+let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+export function startZonePolling() {
+  if (pollInterval) return;
+  pollInterval = setInterval(async () => {
+    try {
+      const status = await api.getZoneControlStatus();
+      zoneStatus.set(status);
+    } catch {
+      // Zone control may not be active
+    }
+  }, 1000);
+}
+
+export function stopZonePolling() {
+  if (pollInterval) {
+    clearInterval(pollInterval);
+    pollInterval = null;
+  }
+  zoneStatus.set(null);
+}
+
+export async function startZoneRide(target: ZoneTarget): Promise<void> {
+  await api.startZoneControl(target);
+  startZonePolling();
+}
+
+export async function stopZoneRide(): Promise<void> {
+  await api.stopZoneControl();
+  stopZonePolling();
+}
+
+export async function pauseZoneRide(): Promise<void> {
+  await api.pauseZoneControl();
+}
+
+export async function resumeZoneRide(): Promise<void> {
+  await api.resumeZoneControl();
+}
+
+/**
+ * Resolve zone number to watts/bpm bounds from user config.
+ * Power zones are stored as %FTP boundaries (zone 1 < power_zone_1% < zone 2 < ... < zone 7).
+ * HR zones are absolute bpm boundaries (zone 1 < hr_zone_1 < zone 2 < ... < zone 5).
+ */
+export function resolveZoneBounds(
+  mode: ZoneMode,
+  zone: number,
+  config: SessionConfig,
+): { lower: number; upper: number } {
+  if (mode === 'Power') {
+    // power_zones = [z1_upper%, z2_upper%, z3_upper%, z4_upper%, z5_upper%, z6_upper%]
+    // zone 1: 0 - pz[0]%, zone 2: pz[0] - pz[1]%, ... zone 7: pz[5]% +
+    const pz = config.power_zones;
+    const ftp = config.ftp;
+    const boundaries = pz.map((p) => Math.round((p / 100) * ftp));
+    if (zone <= 1) return { lower: 0, upper: boundaries[0] };
+    if (zone >= 7) return { lower: boundaries[5], upper: Math.round(ftp * 1.5) };
+    return { lower: boundaries[zone - 2], upper: boundaries[zone - 1] };
+  } else {
+    // hr_zones = [z1_upper, z2_upper, z3_upper, z4_upper, z5_upper]
+    const hz = config.hr_zones;
+    if (zone <= 1) return { lower: 0, upper: hz[0] };
+    if (zone >= 5) return { lower: hz[4], upper: config.max_hr ?? 220 };
+    return { lower: hz[zone - 2], upper: hz[zone - 1] };
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -128,6 +128,49 @@ export interface SessionAnalysis {
   hr_zone_distribution: ZoneBucket[];
 }
 
+export type ZoneMode = 'Power' | 'HeartRate';
+
+export interface ZoneTarget {
+  mode: ZoneMode;
+  zone: number;
+  lower_bound: number;
+  upper_bound: number;
+  duration_secs: number | null;
+}
+
+export interface ZoneControlStatus {
+  active: boolean;
+  mode: ZoneMode | null;
+  target_zone: number | null;
+  lower_bound: number | null;
+  upper_bound: number | null;
+  commanded_power: number | null;
+  time_in_zone_secs: number;
+  elapsed_secs: number;
+  duration_secs: number | null;
+  paused: boolean;
+  phase: string;
+  safety_note: string | null;
+}
+
+export type StopReason =
+  | 'UserStopped'
+  | 'DurationComplete'
+  | 'SafetyStop'
+  | 'TrainerDisconnected'
+  | 'SensorLost';
+
+export interface ZoneRideConfig {
+  mode: ZoneMode;
+  zone: number;
+  lower_bound: number;
+  upper_bound: number;
+  duration_secs: number | null;
+  time_in_zone_secs: number;
+  commanded_power_series: number[];
+  time_to_zone_secs: number | null;
+}
+
 export interface PrereqStatus {
   udev_rules: boolean;
   bluez_installed: boolean;
@@ -191,6 +234,15 @@ export const api = {
       notes,
     }),
   deleteSession: (sessionId: string) => invoke<void>('delete_session', { sessionId }),
+  startZoneControl: (target: ZoneTarget) => invoke<void>('start_zone_control', { target }),
+  stopZoneControl: () => invoke<StopReason | null>('stop_zone_control'),
+  pauseZoneControl: () => invoke<void>('pause_zone_control'),
+  resumeZoneControl: () => invoke<void>('resume_zone_control'),
+  getZoneControlStatus: () => invoke<ZoneControlStatus>('get_zone_control_status'),
+  estimateInitialPower: (targetHr: number) => invoke<number | null>('estimate_initial_power', { targetHr }),
+  saveZoneRideConfig: (sessionId: string, zoneConfig: string) =>
+    invoke<void>('save_zone_ride_config', { sessionId, zoneConfig }),
+  getZoneRideConfig: (sessionId: string) => invoke<string | null>('get_zone_ride_config', { sessionId }),
   checkPrerequisites: () => invoke<PrereqStatus>('check_prerequisites'),
   fixPrerequisites: () => invoke<FixResult>('fix_prerequisites'),
 };

--- a/src/lib/utils/zoneAnalysis.test.ts
+++ b/src/lib/utils/zoneAnalysis.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { computeDecoupling, computeTimeInZone, computeTimeToZone } from './zoneAnalysis';
+
+describe('computeDecoupling', () => {
+  it('constant HR/power ratio yields ~0% decoupling', () => {
+    // 40 points: constant 150bpm / 200W throughout
+    const ts = Array.from({ length: 40 }, () => ({ power: 200, heart_rate: 150 }));
+    const d = computeDecoupling(ts);
+    expect(d).not.toBeNull();
+    expect(Math.abs(d!)).toBeLessThan(0.01);
+  });
+
+  it('HR drifts up 10% in second half yields ~10% decoupling', () => {
+    // First 20: 150bpm / 200W → ratio = 0.75
+    // Second 20: 165bpm / 200W → ratio = 0.825
+    // decoupling = (0.825 - 0.75) / 0.75 * 100 = 10%
+    const first = Array.from({ length: 20 }, () => ({ power: 200, heart_rate: 150 }));
+    const second = Array.from({ length: 20 }, () => ({ power: 200, heart_rate: 165 }));
+    const d = computeDecoupling([...first, ...second]);
+    expect(d).not.toBeNull();
+    expect(d!).toBeCloseTo(10.0, 0);
+  });
+
+  it('returns null with fewer than 20 paired points', () => {
+    const ts = Array.from({ length: 15 }, () => ({ power: 200, heart_rate: 150 }));
+    expect(computeDecoupling(ts)).toBeNull();
+  });
+
+  it('skips null values when counting pairs', () => {
+    // 25 total but 10 have null power → only 15 paired → null
+    const ts = [
+      ...Array.from({ length: 10 }, () => ({ power: null as number | null, heart_rate: 150 })),
+      ...Array.from({ length: 15 }, () => ({ power: 200 as number | null, heart_rate: 150 })),
+    ];
+    expect(computeDecoupling(ts)).toBeNull();
+  });
+
+  it('skips zero-power points', () => {
+    // 25 total but 10 have power=0 → only 15 paired → null
+    const ts = [
+      ...Array.from({ length: 10 }, () => ({ power: 0, heart_rate: 150 })),
+      ...Array.from({ length: 15 }, () => ({ power: 200, heart_rate: 150 })),
+    ];
+    expect(computeDecoupling(ts)).toBeNull();
+  });
+});
+
+describe('computeTimeInZone', () => {
+  it('counts points in each bucket correctly', () => {
+    // Zone: 100-200. 10 points at 1s intervals.
+    // 3 below (50, 80, 90), 4 in zone (100, 150, 175, 200), 3 above (210, 250, 300)
+    const ts = [50, 80, 90, 100, 150, 175, 200, 210, 250, 300].map((v) => ({ value: v }));
+    const result = computeTimeInZone(ts, 100, 200, 1);
+    expect(result.belowSecs).toBe(3);
+    expect(result.inZoneSecs).toBe(4);
+    expect(result.aboveSecs).toBe(3);
+  });
+
+  it('respects intervalSecs multiplier', () => {
+    const ts = [50, 150, 250].map((v) => ({ value: v }));
+    const result = computeTimeInZone(ts, 100, 200, 5);
+    expect(result.belowSecs).toBe(5);
+    expect(result.inZoneSecs).toBe(5);
+    expect(result.aboveSecs).toBe(5);
+  });
+
+  it('skips null values', () => {
+    const ts = [{ value: null }, { value: 150 }, { value: null }];
+    const result = computeTimeInZone(ts, 100, 200, 1);
+    expect(result.inZoneSecs).toBe(1);
+    expect(result.belowSecs).toBe(0);
+    expect(result.aboveSecs).toBe(0);
+  });
+});
+
+describe('computeTimeToZone', () => {
+  it('returns seconds until first in-zone reading', () => {
+    // First 3 out of zone, then in zone
+    const ts = [50, 60, 70, 150, 160].map((v) => ({ value: v }));
+    expect(computeTimeToZone(ts, 100, 200, 1)).toBe(3);
+  });
+
+  it('returns 0 when first reading is in zone', () => {
+    const ts = [150, 160, 170].map((v) => ({ value: v }));
+    expect(computeTimeToZone(ts, 100, 200, 1)).toBe(0);
+  });
+
+  it('returns null when never reaching zone', () => {
+    const ts = [50, 60, 70].map((v) => ({ value: v }));
+    expect(computeTimeToZone(ts, 100, 200, 1)).toBeNull();
+  });
+
+  it('respects intervalSecs', () => {
+    const ts = [50, 60, 150].map((v) => ({ value: v }));
+    expect(computeTimeToZone(ts, 100, 200, 5)).toBe(10);
+  });
+
+  it('skips null values (does not count as in-zone)', () => {
+    const ts = [{ value: null }, { value: null }, { value: 150 }];
+    expect(computeTimeToZone(ts, 100, 200, 1)).toBe(2);
+  });
+});

--- a/src/lib/utils/zoneAnalysis.ts
+++ b/src/lib/utils/zoneAnalysis.ts
@@ -1,0 +1,93 @@
+/**
+ * Post-ride zone analysis utilities.
+ * Pure functions for computing decoupling, time-in-zone, and time-to-zone.
+ */
+
+interface HrPowerPoint {
+  power: number | null;
+  heart_rate: number | null;
+}
+
+interface ValuePoint {
+  value: number | null;
+}
+
+/**
+ * Compute HR:Power decoupling percentage.
+ *
+ * Splits paired (HR, power) data into first and second halves,
+ * computes the HR/power ratio for each half, and returns the
+ * percentage change. Higher decoupling indicates cardiac drift.
+ *
+ * Returns null if fewer than 20 paired data points.
+ */
+export function computeDecoupling(timeseries: HrPowerPoint[]): number | null {
+  const paired = timeseries.filter(
+    (pt): pt is { power: number; heart_rate: number } =>
+      pt.power != null && pt.heart_rate != null && pt.power > 0,
+  );
+
+  if (paired.length < 20) return null;
+
+  const mid = Math.floor(paired.length / 2);
+  const firstHalf = paired.slice(0, mid);
+  const secondHalf = paired.slice(mid);
+
+  const avgHr1 = firstHalf.reduce((s, p) => s + p.heart_rate, 0) / firstHalf.length;
+  const avgPw1 = firstHalf.reduce((s, p) => s + p.power, 0) / firstHalf.length;
+  const avgHr2 = secondHalf.reduce((s, p) => s + p.heart_rate, 0) / secondHalf.length;
+  const avgPw2 = secondHalf.reduce((s, p) => s + p.power, 0) / secondHalf.length;
+
+  if (avgPw1 === 0 || avgPw2 === 0) return null;
+
+  const ratio1 = avgHr1 / avgPw1;
+  const ratio2 = avgHr2 / avgPw2;
+
+  return ((ratio2 - ratio1) / ratio1) * 100;
+}
+
+/**
+ * Compute time spent in/below/above a zone from a value series.
+ *
+ * Each point represents one `intervalSecs` of data.
+ * Null values are skipped (not counted in any bucket).
+ */
+export function computeTimeInZone(
+  timeseries: ValuePoint[],
+  lower: number,
+  upper: number,
+  intervalSecs: number,
+): { inZoneSecs: number; belowSecs: number; aboveSecs: number } {
+  let inZoneSecs = 0;
+  let belowSecs = 0;
+  let aboveSecs = 0;
+
+  for (const pt of timeseries) {
+    if (pt.value == null) continue;
+    if (pt.value < lower) belowSecs += intervalSecs;
+    else if (pt.value > upper) aboveSecs += intervalSecs;
+    else inZoneSecs += intervalSecs;
+  }
+
+  return { inZoneSecs, belowSecs, aboveSecs };
+}
+
+/**
+ * Compute the time (in seconds) until the first in-zone reading.
+ *
+ * Returns null if the value never enters the zone.
+ */
+export function computeTimeToZone(
+  timeseries: ValuePoint[],
+  lower: number,
+  upper: number,
+  intervalSecs: number,
+): number | null {
+  for (let i = 0; i < timeseries.length; i++) {
+    const v = timeseries[i].value;
+    if (v != null && v >= lower && v <= upper) {
+      return i * intervalSecs;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add zone ride modes targeting power zones (ERG-based) or HR zones (PID-controlled) with configurable duration
- Implement PID controller with adaptive gains, HR smoothing, and safety guards (cadence zero, HR ceiling, sensor loss, trainer disconnect)
- Add real-time zone status strip, zone band overlay on MetricsChart, and post-ride analytics (decoupling, time-in-zone, zone summary)
- Persist zone config per session with historical HR-power regression for smarter initial power estimates

## Test Plan
- [ ] 237 Rust tests pass (`cd src-tauri && cargo test`)
- [ ] 66 frontend tests pass (`npx vitest run`) — includes 13 zone analysis tests
- [ ] 0 TypeScript errors (`npm run check`)
- [ ] Start a power zone ride — verify ERG target set to zone midpoint
- [ ] Start an HR zone ride — verify PID adjusts power to reach target HR
- [ ] Verify safety guards: stop pedaling triggers power reduction, HR ceiling triggers safety stop
- [ ] Complete a zone ride and check post-ride analytics on history detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)