### PR TITLE
Add PMC ramp rate to analytics page

### DIFF
--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -136,6 +136,28 @@ export function computeWeeklyTrends(sessions: SessionSummary[]): WeekBucket[] {
     }));
 }
 
+export interface RampRate {
+  current: number; // CTL delta over 7 days
+  classification:
+    | 'recovery'
+    | 'maintenance'
+    | 'moderate'
+    | 'aggressive'
+    | 'excessive';
+}
+
+export function computeRampRate(pmcData: PmcDay[]): RampRate | null {
+  if (pmcData.length < 8) return null;
+  const current = pmcData[pmcData.length - 1].ctl - pmcData[pmcData.length - 8].ctl;
+  let classification: RampRate['classification'];
+  if (current < -2) classification = 'recovery';
+  else if (current < 2) classification = 'maintenance';
+  else if (current < 5) classification = 'moderate';
+  else if (current < 8) classification = 'aggressive';
+  else classification = 'excessive';
+  return { current, classification };
+}
+
 /** Extract FTP change points: emit when FTP value changes from previous. Always emit first and last. */
 export function extractFtpProgression(sessions: SessionSummary[]): FtpPoint[] {
   const sorted = [...sessions]


### PR DESCRIPTION
## Summary
- Compute 7-day CTL delta (ramp rate) from PMC data and classify as recovery/maintenance/moderate/aggressive/excessive
- Display color-coded MetricCard on the analytics dashboard (green=moderate, orange=aggressive, red=excessive, gray=maintenance/recovery)
- Update summary cards grid to `auto-fill` for flexible layout with the new 6th card
- Add 5 unit tests covering null/edge/classification cases

## Test plan
- [x] `npx vitest run src/lib/utils/analytics.test.ts` — 23 tests pass
- [x] `npm run check` — 0 TS errors