### PR TITLE
Add power curve historical overlay

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -337,6 +337,8 @@ pub fn run() {
             commands::estimate_initial_power,
             commands::save_zone_ride_config,
             commands::get_zone_ride_config,
+            commands::get_best_power_curve,
+            commands::backfill_power_curves,
             commands::check_prerequisites,
             commands::fix_prerequisites,
         ])

--- a/src-tauri/src/session/analysis.rs
+++ b/src-tauri/src/session/analysis.rs
@@ -94,6 +94,12 @@ pub fn compute_pwc(timeseries: &[TimeseriesPoint]) -> Option<PwcMarkers> {
     })
 }
 
+/// Compute power curve from raw sensor readings.
+/// Public wrapper for use by power curve storage and backfill.
+pub fn compute_power_curve_from_readings(readings: &[SensorReading]) -> Vec<PowerCurvePoint> {
+    compute_power_curve(readings)
+}
+
 /// Build a 1-second timeseries from raw sensor readings.
 /// Public wrapper for use by zone control history estimation.
 pub fn build_timeseries_from_readings(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -255,6 +255,9 @@ export const api = {
   saveZoneRideConfig: (sessionId: string, zoneConfig: string) =>
     invoke<void>('save_zone_ride_config', { sessionId, zoneConfig }),
   getZoneRideConfig: (sessionId: string) => invoke<string | null>('get_zone_ride_config', { sessionId }),
+  getBestPowerCurve: (period: string) =>
+    invoke<PowerCurvePoint[]>('get_best_power_curve', { period }),
+  backfillPowerCurves: () => invoke<number>('backfill_power_curves'),
   checkPrerequisites: () => invoke<PrereqStatus>('check_prerequisites'),
   fixPrerequisites: () => invoke<FixResult>('fix_prerequisites'),
 };


### PR DESCRIPTION
## Summary
- New `session_power_curves` SQLite table to cache per-session power curves
- `get_best_power_curve` command with period filter (all/90d/30d) returns MAX watts across sessions at each duration
- `backfill_power_curves` command iterates all sessions, skipping those already cached, and computes+stores their curves
- `stop_session` now saves the power curve in a background task after persisting the session
- `delete_session` cleans up associated power curve rows
- `PowerCurve.svelte` gains an `overlays` prop for rendering dashed best-of lines with legend and multi-series tooltip
- Session detail page adds an All/90d/30d period toggle above the power curve chart, fetches best curve reactively, and triggers backfill on mount

## Test plan
- [x] `cargo test` — 251 tests pass (4 new storage tests: round-trip, max-across-sessions, has-detection, cascade-delete)
- [x] `npm run check` — 0 TS errors
- [x] `npm run build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)