### PR TITLE
Add adaptive zone ride UX improvements

### DIFF
--- a/src/lib/components/ZoneRideStatus.svelte
+++ b/src/lib/components/ZoneRideStatus.svelte
@@ -33,6 +33,13 @@
     return z ? `Z${z} ${m}` : m;
   });
 
+  let modeDescription = $derived.by(() => {
+    if (!$zoneStatus) return '';
+    const z = $zoneStatus.target_zone;
+    const m = $zoneStatus.mode === 'HeartRate' ? 'HR' : 'Power';
+    return z ? `${m} Zone ${z}` : m;
+  });
+
   let remaining = $derived.by(() => {
     if (!$zoneStatus?.duration_secs) return null;
     const left = $zoneStatus.duration_secs - $zoneStatus.elapsed_secs;
@@ -47,6 +54,11 @@
 
 {#if $zoneStatus?.active}
   <div class="zone-status" style="--zone-color: {zoneColor}">
+    <div class="status-header">
+      <span class="ride-type-label">ADAPTIVE ZONE</span>
+      <span class="ride-target-label">{modeDescription}</span>
+    </div>
+
     {#if progress != null}
       <div class="progress-track">
         <div class="progress-fill" style="width: {progress}%"></div>
@@ -73,14 +85,20 @@
       <span class="status-sep"></span>
 
       <span class="time-stat">
+        <span class="time-label">Elapsed</span>
+        <span class="time-value">{formatDuration($zoneStatus.elapsed_secs)}</span>
+      </span>
+
+      <span class="time-stat">
         <span class="time-label">In zone</span>
         <span class="time-value">{formatDuration($zoneStatus.time_in_zone_secs)}</span>
       </span>
 
-      {#if remaining != null}
+      {#if remaining != null && $zoneStatus.duration_secs}
         <span class="time-stat">
           <span class="time-label">Left</span>
           <span class="time-value">{formatDuration(remaining)}</span>
+          <span class="time-total">/ {formatDuration($zoneStatus.duration_secs)}</span>
         </span>
       {/if}
 
@@ -112,6 +130,27 @@
   @keyframes slide-up {
     from { opacity: 0; transform: translateY(4px); }
     to { opacity: 1; transform: translateY(0); }
+  }
+
+  .status-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-xs) var(--space-md);
+    border-bottom: 1px solid color-mix(in srgb, var(--zone-color) 15%, var(--border-subtle));
+  }
+
+  .ride-type-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: var(--zone-color);
+  }
+
+  .ride-target-label {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-muted);
   }
 
   .progress-track {
@@ -211,6 +250,14 @@
     font-variant-numeric: tabular-nums;
     font-weight: 700;
     color: var(--text-primary);
+  }
+
+  .time-total {
+    font-family: var(--font-data);
+    font-size: var(--text-xs);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+    font-weight: 500;
   }
 
   .cmd-power {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -229,6 +229,12 @@
         <input type="checkbox" bind:checked={$autoSessionEnabled} />
         <span class="auto-toggle-label">Auto</span>
       </label>
+      {#if $zoneActive}
+        <span class="zone-active-badge">
+          <span class="zone-active-dot"></span>
+          Zone Ride
+        </span>
+      {/if}
     </div>
 
     <!-- Trainer controls -->
@@ -536,6 +542,29 @@
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-secondary);
+  }
+
+  .zone-active-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: var(--space-xs) var(--space-md);
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    animation: slide-up 200ms ease;
+  }
+
+  .zone-active-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse 2s ease-in-out infinite;
   }
 
   .btn-zone-toggle {


### PR DESCRIPTION
## Summary
- Add "ADAPTIVE ZONE" header with mode description (e.g. "Power Zone 3") to the zone status bar, making the active ride type immediately obvious
- Add elapsed time display alongside in-zone time, and show total duration context on remaining time (e.g. "19:32 / 20:00")
- Add pulsing "Zone Ride" pill badge in session controls row when zone ride is active

## Test plan
- [ ] `npm run check` passes with 0 errors
- [ ] `npm run build` completes cleanly
- [ ] Start a session with trainer connected, open zone builder, select Power Zone 3 with 20 min duration
- [ ] Verify "ADAPTIVE ZONE" header appears with "Power Zone 3" label
- [ ] Verify "Elapsed" time stat appears alongside "In zone"
- [ ] Verify "Left" shows remaining / total format
- [ ] Verify "Zone Ride" badge with pulsing dot appears in session controls
- [ ] Stop zone ride and verify status bar and badge disappear