### PR TITLE
Add batch upserts, push device events, and ANT+ panic guard

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -211,6 +211,13 @@ pub fn run() {
                                 for info in &disconnected {
                                     let _ = handle.emit("device_disconnected", &info.id);
                                 }
+
+                                // Push updated device list
+                                {
+                                    let dm = dm.lock().await;
+                                    let all = dm.list_current().await;
+                                    let _ = handle.emit("device_list_updated", &all);
+                                }
                             }
 
                             // Attempt reconnects for devices due for retry
@@ -224,6 +231,12 @@ pub fn run() {
                                 let mut p = primaries.lock().await;
                                 p.entry(info.device_type)
                                     .or_insert_with(|| info.id.clone());
+                            }
+
+                            if !reconnected.is_empty() {
+                                let dm = dm.lock().await;
+                                let all = dm.list_current().await;
+                                let _ = handle.emit("device_list_updated", &all);
                             }
 
                             for (info, attempt) in &trying {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,8 @@
   import { page } from '$app/stores';
   import { onMount, onDestroy } from 'svelte';
   import { startSensorListening, stopSensorListening } from '$lib/stores/sensor';
-  import { refreshDevices, handleDeviceDisconnected, handleDeviceReconnecting, handleDeviceReconnected } from '$lib/stores/devices';
+  import { refreshDevices, connectedDevices, handleDeviceDisconnected, handleDeviceReconnecting, handleDeviceReconnected } from '$lib/stores/devices';
+  import type { DeviceInfo } from '$lib/tauri';
   import { initAutoSession, destroyAutoSession } from '$lib/stores/autoSession';
   import { unitSystem } from '$lib/stores/units';
   import { api } from '$lib/tauri';
@@ -45,7 +46,12 @@
     listenPromises.push(
       listen<string>('device_reconnected', (event) => {
         handleDeviceReconnected(event.payload);
-        refreshDevices();
+      })
+    );
+
+    listenPromises.push(
+      listen<DeviceInfo[]>('device_list_updated', (event) => {
+        connectedDevices.set(event.payload);
       })
     );
 


### PR DESCRIPTION
## Summary
- **#117 Batch upserts**: `scan_all` now persists all discovered devices in a single SQLite transaction instead of N individual INSERTs
- **#122 Push events**: `scan_devices`, `connect_device`, `disconnect_device` commands and the connection watchdog emit `device_list_updated` events so the frontend updates reactively without polling
- **#125 ANT+ panic guard**: `with_ant_blocking` helper encapsulates the take/spawn_blocking/put-back pattern, ensuring AntManager is always returned even on panic

Closes #117, closes #122, closes #125

## Test plan
- [x] `cargo test` — 255/255 pass (including new `upsert_batch_coalesce_preserves`)
- [x] `npm run check` — 0 TS errors
- [x] `npm run build` — clean production build
- [ ] Manual: connect ANT+ and BLE devices, verify devices page updates reactively
- [ ] Manual: scan — verify batch persist (single transaction vs per-device)
- [ ] Manual: disconnect/reconnect — verify device list pushes to frontend