### PR TITLE
Replace live metrics polling with push-based events

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,7 +11,7 @@ use crate::session::analysis::{self, PowerCurvePoint, SessionAnalysis};
 use crate::session::fit_export;
 use crate::session::manager::SessionManager;
 use crate::session::storage::Storage;
-use crate::session::types::{LiveMetrics, SessionConfig, SessionSummary};
+use crate::session::types::{SessionConfig, SessionSummary};
 use crate::session::analysis::{compute_hr_power_regression, TimeseriesPoint};
 use crate::session::zone_control::controller::ZoneController;
 use crate::session::zone_control::types::{StopReason, ZoneControlStatus, ZoneMode, ZoneTarget};
@@ -169,11 +169,6 @@ pub async fn pause_session(state: State<'_, AppState>) -> Result<(), AppError> {
 pub async fn resume_session(state: State<'_, AppState>) -> Result<(), AppError> {
     state.session_manager.resume_session().await;
     Ok(())
-}
-
-#[tauri::command]
-pub async fn get_live_metrics(state: State<'_, AppState>) -> Result<Option<LiveMetrics>, AppError> {
-    Ok(state.session_manager.get_live_metrics().await)
 }
 
 #[tauri::command]

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -214,7 +214,6 @@ export const api = {
   stopSession: () => invoke<SessionSummary | null>('stop_session'),
   pauseSession: () => invoke<void>('pause_session'),
   resumeSession: () => invoke<void>('resume_session'),
-  getLiveMetrics: () => invoke<LiveMetrics | null>('get_live_metrics'),
   listSessions: () => invoke<SessionSummary[]>('list_sessions'),
   getSession: (sessionId: string) => invoke<SessionSummary>('get_session', { sessionId }),
   getSessionAnalysis: (sessionId: string) => invoke<SessionAnalysis>('get_session_analysis', { sessionId }),


### PR DESCRIPTION
## Summary
- Spawns a dedicated 250ms timer task in `lib.rs` that emits `live_metrics` events whenever a session is active, replacing the frontend's `setInterval` polling of the `get_live_metrics` IPC command
- Removes the `get_live_metrics` Tauri command (backend + frontend) since it's no longer needed
- Frontend subscribes to `live_metrics` events via `listen()` alongside the existing `sensor_reading` listener

Closes #116

## Test plan
- [x] `cargo test` — 255 tests pass
- [x] `npm run check` — 0 TS errors
- [ ] Manual: start a session, verify live metrics (elapsed time, NP, TSS, zones) update in real time
- [ ] Manual: stop session, verify metrics stop updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)