### PR TITLE
Filter non-primary readings at source (#121)

### DIFF
--- a/src-tauri/src/device/ant_manager.rs
+++ b/src-tauri/src/device/ant_manager.rs
@@ -289,6 +289,7 @@ impl AntManager {
         &mut self,
         device_id: &str,
         tx: broadcast::Sender<SensorReading>,
+        primaries: Option<Arc<std::sync::RwLock<HashMap<DeviceType, String>>>>,
     ) -> Result<DeviceInfo, AppError> {
         let discovered = self
             .discovered
@@ -328,7 +329,7 @@ impl AntManager {
         }
 
         let listener_handle = tokio::task::spawn_blocking(move || {
-            listen_ant_channel(data_rx, device_type, tx, stop_clone, did, metadata, dtype_id, last_seen_ts);
+            listen_ant_channel(data_rx, device_type, tx, stop_clone, did, metadata, dtype_id, last_seen_ts, primaries);
         });
 
         let info = DeviceInfo {


### PR DESCRIPTION
## Summary
- Move primary-device filtering from the global processor (`lib.rs`) into BLE and ANT+ listeners, so dominated readings never enter the broadcast channel
- Switch `primary_devices` from `tokio::sync::Mutex` to `std::sync::RwLock` so blocking ANT+ listener threads can read without `.await`
- Add shared `is_dominated()` helper in `types.rs` with 7 unit tests

## Test plan
- [x] `cargo test` — 262 tests pass (including 7 new `is_dominated` tests)
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Manual: connect two power meters, set one as primary, verify only primary readings appear in session data
- [ ] Manual: verify ANT+ and BLE devices both filter correctly

Closes #121