### PR TITLE
Consolidate primary device state into DeviceManager (#118)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,7 +176,6 @@ pub fn run() {
                 // the auto-reconnect engine.
                 {
                     let dm = device_manager.clone();
-                    let primaries = primary_devices.clone();
                     let handle = app_handle.clone();
                     let sensor_tx_clone = sensor_tx.clone();
                     tokio::spawn(async move {
@@ -189,14 +188,6 @@ pub fn run() {
                             };
 
                             if !disconnected.is_empty() {
-                                // Clean up primaries
-                                {
-                                    let mut p = primaries.write().unwrap();
-                                    let ids: Vec<String> =
-                                        disconnected.iter().map(|i| i.id.clone()).collect();
-                                    p.retain(|_, v| !ids.contains(v));
-                                }
-
                                 // Emit disconnect events to frontend
                                 for info in &disconnected {
                                     let _ = handle.emit("device_disconnected", &info.id);
@@ -218,9 +209,6 @@ pub fn run() {
 
                             for info in &reconnected {
                                 let _ = handle.emit("device_reconnected", &info.id);
-                                let mut p = primaries.write().unwrap();
-                                p.entry(info.device_type)
-                                    .or_insert_with(|| info.id.clone());
                             }
 
                             if !reconnected.is_empty() {


### PR DESCRIPTION
## Summary
- Move `auto_set_primary()` and `remove_primary()` into `DeviceManager` as private methods, called from `connect_ble()`, `connect_ant()`, `disconnect()`, `check_connections()`, and `attempt_reconnects()`
- Remove standalone helper functions and their callers from `commands.rs` (connect_device, disconnect_device)
- Remove primary management blocks from `lib.rs` watchdog task (disconnect cleanup, reconnect auto-set)

Net: -74 lines. Every connect/disconnect path now updates primaries in one place.

## Test plan
- [x] `cargo test` — 257 pass
- [x] `npm run check` — 0 errors
- [ ] Manual: connect device → verify it becomes primary
- [ ] Manual: disconnect device → verify primary cleared
- [ ] Manual: silent disconnect (watchdog) → verify primary cleared
- [ ] Manual: auto-reconnect → verify primary restored