### PR TITLE
Add diagnostic logging across command, device, and session layers

### DIFF
--- a/src-tauri/src/device/ant_protocol.rs
+++ b/src-tauri/src/device/ant_protocol.rs
@@ -1,3 +1,5 @@
+use log::debug;
+
 use super::types::SensorReading;
 
 /// Default wheel circumference in mm (700x25c)
@@ -63,6 +65,7 @@ impl AntDecoder {
     pub fn decode_power(&mut self, data: &[u8; 8], device_id: &str) -> Option<SensorReading> {
         let page = data[0];
         if page != 0x10 {
+            debug!("ANT+ power: unhandled page 0x{:02X} from {}", page, device_id);
             return None; // Only decode standard power page
         }
 
@@ -135,6 +138,7 @@ impl AntDecoder {
         let rpm = (rev_diff as f32 / time_secs) * 60.0;
 
         if rpm > 200.0 || rpm < 0.0 {
+            debug!("ANT+ cadence: out-of-range {:.0} rpm from {}", rpm, device_id);
             return None;
         }
 
@@ -179,6 +183,7 @@ impl AntDecoder {
         let kmh = (distance_m / time_secs) * 3.6;
 
         if kmh > 120.0 || kmh < 0.0 {
+            debug!("ANT+ speed: out-of-range {:.1} km/h from {}", kmh, device_id);
             return None;
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,6 +292,7 @@ pub fn run() {
             });
 
             app.manage(state);
+            log::info!("Application startup complete");
             Ok(())
         })
         .on_window_event(|window, event| {

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -111,6 +111,7 @@ impl SessionManager {
 
     pub async fn pause_session(&self) {
         if let Some(session) = self.current_session.lock().await.as_mut() {
+            info!("Session paused: {}", session.id);
             session.status = SessionStatus::Paused;
             // Clear last_reading_time so resume doesn't count the pause gap
             session.last_reading_time = None;
@@ -119,6 +120,7 @@ impl SessionManager {
 
     pub async fn resume_session(&self) {
         if let Some(session) = self.current_session.lock().await.as_mut() {
+            info!("Session resumed: {}", session.id);
             session.status = SessionStatus::Running;
         }
     }


### PR DESCRIPTION
## Summary
- Adds ~45 targeted log statements across 8 files to improve debuggability of user-reported issues
- `info!` at all command entry points and session/connection state transitions
- `warn!` for safety decisions (cadence zero, HR ceiling), trainer command failures, and previously-swallowed errors (`.ok()` patterns replaced with explicit logging)
- `debug!` for PID adjustments, phase transitions, and BLE/ANT+ decode anomalies
- No behavioral changes — logging only

## Test plan
- [x] `cargo test` — 263 tests pass
- [x] `npm run check` — 0 TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)