### PR TITLE
Remove 5 dead public methods

### DIFF
--- a/src-tauri/src/device/manager.rs
+++ b/src-tauri/src/device/manager.rs
@@ -586,10 +586,6 @@ impl DeviceManager {
         self.reconnect.remove(device_id);
     }
 
-    pub fn clear_all_reconnect_targets(&mut self) {
-        self.reconnect.clear();
-    }
-
     // Trainer control methods -- C2: FE-C calls wrapped in spawn_blocking
 
     pub async fn set_target_power(&mut self, device_id: &str, watts: i16) -> Result<(), AppError> {

--- a/src-tauri/src/device/reconnect.rs
+++ b/src-tauri/src/device/reconnect.rs
@@ -49,14 +49,6 @@ impl ReconnectManager {
         }
     }
 
-    /// Clear all targets
-    pub fn clear(&mut self) {
-        if !self.targets.is_empty() {
-            log::info!("Cleared {} auto-reconnect targets", self.targets.len());
-            self.targets.clear();
-        }
-    }
-
     /// Return devices due for a retry attempt and bump their backoff
     pub fn due_for_retry(&mut self) -> Vec<DeviceInfo> {
         let now = Instant::now();
@@ -71,10 +63,6 @@ impl ReconnectManager {
             }
         }
         due
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.targets.is_empty()
     }
 
     pub fn attempt_count(&self, device_id: &str) -> u32 {
@@ -140,10 +128,10 @@ mod tests {
     fn remove_clears_target() {
         let mut rm = ReconnectManager::new();
         rm.register(test_device("dev1"));
-        assert!(!rm.is_empty());
+        assert!(!rm.targets.is_empty());
 
         rm.remove("dev1");
-        assert!(rm.is_empty());
+        assert!(rm.targets.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/session/zone_control/controller.rs
+++ b/src-tauri/src/session/zone_control/controller.rs
@@ -104,16 +104,6 @@ impl ZoneController {
         }
     }
 
-    pub async fn start(
-        &mut self,
-        target: ZoneTarget,
-        device_manager: Arc<Mutex<DeviceManager>>,
-        sensor_tx: broadcast::Sender<SensorReading>,
-    ) -> Result<(), AppError> {
-        self.start_with_config(target, device_manager, sensor_tx, None, None, None)
-            .await
-    }
-
     pub async fn start_with_config(
         &mut self,
         target: ZoneTarget,

--- a/src-tauri/src/session/zone_control/pid.rs
+++ b/src-tauri/src/session/zone_control/pid.rs
@@ -45,11 +45,6 @@ impl PidController {
         output.clamp(-self.output_limit, self.output_limit)
     }
 
-    pub fn reset(&mut self) {
-        self.integral = 0.0;
-        self.prev_error = None;
-    }
-
     pub fn set_gains(&mut self, kp: f64, ki: f64, kd: f64) {
         self.kp = kp;
         self.ki = ki;
@@ -188,17 +183,11 @@ mod tests {
     }
 
     #[test]
-    fn reset_clears_state() {
+    fn fresh_pid_has_no_accumulated_state() {
+        // I-only controller: error=5, dt=1 → integral=5, output=5
         let mut pid = PidController::with_limits(0.0, 1.0, 1.0, 200.0, 100.0);
-        pid.update(10.0, 1.0);
-        pid.update(20.0, 1.0);
-
-        pid.reset();
-
-        // After reset, integral should be 0 and no prev_error
-        // I-only: error=5, dt=1 → integral=5, output=5
         let out = pid.update(5.0, 1.0);
-        assert_approx(out, 5.0, 0.01, "after reset, integral starts fresh");
+        assert_approx(out, 5.0, 0.01, "fresh PID has no prior integral or derivative");
     }
 
     // --- HrSmoother tests ---


### PR DESCRIPTION
## Summary
- Delete `DeviceManager::clear_all_reconnect_targets()` — never called
- Delete `ReconnectManager::clear()` — only caller was the above
- Delete `ReconnectManager::is_empty()` — only used in tests; test updated to access `targets` directly
- Delete `ZoneController::start()` — all callers use `start_with_config()` instead
- Delete `PidController::reset()` — only used in one test; test rewritten to verify fresh construction

Eliminates all 5 dead-code compiler warnings.

Closes #136

## Test plan
- [x] `cargo test` — 257 tests pass
- [x] All previous dead-code warnings gone (only 2 unrelated test-helper warnings remain)