### PR TITLE
Use DeviceType::as_str() instead of Debug format (#137)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -40,11 +40,11 @@ fn validate_zones_ascending<T: PartialOrd>(zones: &[T], label: &str) -> Result<(
     Ok(())
 }
 
-/// Format primary devices map for the frontend (DeviceType debug keys → string keys).
+/// Format primary devices map for the frontend (DeviceType → stable string keys).
 fn format_primaries(primaries: &HashMap<DeviceType, String>) -> HashMap<String, String> {
     primaries
         .iter()
-        .map(|(k, v)| (format!("{:?}", k), v.clone()))
+        .map(|(k, v)| (k.as_str().to_owned(), v.clone()))
         .collect()
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -220,7 +220,7 @@ pub fn run() {
                                 let _ =
                                     handle.emit("device_reconnecting", &serde_json::json!({
                                         "device_id": info.id,
-                                        "device_type": format!("{:?}", info.device_type),
+                                        "device_type": info.device_type.as_str(),
                                         "attempt": attempt,
                                     }));
                             }


### PR DESCRIPTION
## Summary
- Replace `format!("{:?}", k)` with `k.as_str().to_owned()` in `format_primaries()` (commands.rs)
- Replace `format!("{:?}", info.device_type)` with `info.device_type.as_str()` in the `device_reconnecting` event (lib.rs)
- No frontend changes needed — `as_str()` already returns the same strings the frontend expects

## Test plan
- [ ] `cargo check` passes
- [ ] Verify device page still shows correct primary device labels
- [ ] Verify reconnecting toast shows correct device type

Closes #137