### PR TITLE
Clarify and centralize staleness thresholds (#139)

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -10,8 +10,16 @@ pub const LIVE_METRICS_PUSH_MS: u64 = 250;
 /// BLE scan duration — how long a BLE scan runs before returning results.
 pub const BLE_SCAN_DURATION_SECS: u64 = 3;
 
-/// ANT+ staleness threshold — device considered disconnected after this many seconds without data.
-pub const ANT_STALE_SECS: u64 = 10;
+/// Device disconnect timeout — ANT+ device considered lost after this many seconds
+/// without data. Intentionally longer than READING_FRESHNESS_SECS: we stop using
+/// stale data for metrics quickly (5s) but give the device more time (10s) before
+/// triggering disconnect/reconnect logic.
+pub const DEVICE_DISCONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Reading freshness window — readings older than this are ignored by the session
+/// metrics engine. Shorter than DEVICE_DISCONNECT_TIMEOUT_SECS so metrics stay
+/// responsive even while the watchdog still considers the device connected.
+pub const READING_FRESHNESS_SECS: u64 = 5;
 
 /// Reconnect initial backoff — delay before first reconnect attempt.
 pub const RECONNECT_INITIAL_BACKOFF_MS: u64 = 2000;

--- a/src-tauri/src/device/manager.rs
+++ b/src-tauri/src/device/manager.rs
@@ -517,7 +517,7 @@ impl DeviceManager {
             for id in ant_ids {
                 if let Some(ts) = last_seen.get(&id) {
                     if let Some(elapsed) = super::ant::listener::atomic_elapsed(ts) {
-                        if elapsed > std::time::Duration::from_secs(config::ANT_STALE_SECS) {
+                        if elapsed > std::time::Duration::from_secs(config::DEVICE_DISCONNECT_TIMEOUT_SECS) {
                             if let Some(info) = self.connected_devices.get(&id) {
                                 disconnected.push(info.clone());
                             }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -9,8 +9,7 @@ use super::metrics::MetricsCalculator;
 use super::types::*;
 use crate::device::types::SensorReading;
 
-/// Data is considered stale after this many seconds without a new reading.
-const STALE_THRESHOLD_SECS: u64 = 5;
+use crate::config;
 
 pub struct SessionManager {
     current_session: Arc<Mutex<Option<ActiveSession>>>,
@@ -173,7 +172,7 @@ impl SessionManager {
     pub async fn get_live_metrics(&self) -> Option<LiveMetrics> {
         let lock = self.current_session.lock().await;
         let session = lock.as_ref()?;
-        let stale_threshold = std::time::Duration::from_secs(STALE_THRESHOLD_SECS);
+        let stale_threshold = std::time::Duration::from_secs(config::READING_FRESHNESS_SECS);
         let is_stale = |last: Option<Instant>| -> bool {
             last.is_some_and(|t| t.elapsed() > stale_threshold)
         };


### PR DESCRIPTION
## Summary
- Rename `ANT_STALE_SECS` → `DEVICE_DISCONNECT_TIMEOUT_SECS` (10s) in config.rs
- Move `STALE_THRESHOLD_SECS` from session/manager.rs → `READING_FRESHNESS_SECS` (5s) in config.rs
- Document the intentional difference: metrics freshness (5s) vs device disconnect (10s)
- No value changes, pure naming/documentation improvement

## Test plan
- [ ] `cargo test` — all 263 tests pass

Closes #139