### PR TITLE
Replace catch-all string errors with structured BleError/AntError sub-enums (#138)

### DIFF
--- a/src-tauri/src/device/ant/channel.rs
+++ b/src-tauri/src/device/ant/channel.rs
@@ -1,6 +1,6 @@
 use super::usb::*;
 use crate::device::types::DeviceType;
-use crate::error::AppError;
+use crate::error::{AntError, AppError};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -268,19 +268,19 @@ pub fn poll_response(
                 if code == RESPONSE_NO_ERROR {
                     return Ok(());
                 } else {
-                    return Err(AppError::AntPlus(format!(
+                    return Err(AntError::Channel(format!(
                         "ANT ch{} command {:#x} failed with code {:#x}",
                         channel_number, expected_msg_id, code
-                    )));
+                    )).into());
                 }
             }
         }
         std::thread::sleep(Duration::from_millis(10));
     }
-    Err(AppError::AntPlus(format!(
+    Err(AntError::Channel(format!(
         "Timeout waiting for ch{} response to {:#x}",
         channel_number, expected_msg_id
-    )))
+    )).into())
 }
 
 /// Wait for a channel response by reading directly from USB.
@@ -296,17 +296,17 @@ fn wait_for_response_direct(usb: &AntUsb, expected_msg_id: u8) -> Result<(), App
                     if code == RESPONSE_NO_ERROR {
                         return Ok(());
                     } else {
-                        return Err(AppError::AntPlus(format!(
+                        return Err(AntError::Channel(format!(
                             "ANT command {:#x} failed with code {:#x}",
                             expected_msg_id, code
-                        )));
+                        )).into());
                     }
                 }
             }
         }
     }
-    Err(AppError::AntPlus(format!(
+    Err(AntError::Channel(format!(
         "Timeout waiting for response to {:#x}",
         expected_msg_id
-    )))
+    )).into())
 }

--- a/src-tauri/src/device/ant/manager.rs
+++ b/src-tauri/src/device/ant/manager.rs
@@ -10,7 +10,7 @@ use super::channel::*;
 use super::listener::listen_ant_channel;
 use super::usb::*;
 use crate::device::types::*;
-use crate::error::AppError;
+use crate::error::{AntError, AppError};
 
 /// Information about a discovered ANT+ device
 #[derive(Debug, Clone)]
@@ -117,11 +117,11 @@ impl AntManager {
                 return Ok(ch);
             }
         }
-        Err(AppError::AntPlus(format!(
-            "All ANT+ channels in use ({} connected, {} reserved for scanning)",
+        Err(AntError::NoFreeChannel(format!(
+            "{} connected, {} reserved for scanning",
             used.len(),
             reserved
-        )))
+        )).into())
     }
 
     /// Scan for ANT+ devices. Opens wildcard channels for each profile,

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,11 +1,41 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+pub enum BleError {
+    #[error("BLE not initialized")]
+    NotInitialized,
+    #[error("No BLE adapter found")]
+    NoAdapter,
+    #[error("No recognized services on device {0}")]
+    UnrecognizedDevice(String),
+    #[error("Characteristic not found: {0}")]
+    CharacteristicNotFound(String),
+    #[error("{0}")]
+    Btleplug(String),
+}
+
+#[derive(Error, Debug)]
+pub enum AntError {
+    #[error("No ANT+ USB stick found")]
+    NoUsbStick,
+    #[error("All ANT+ channels in use ({0})")]
+    NoFreeChannel(String),
+    #[error("Not supported: {0}")]
+    NotSupported(String),
+    #[error("ANT+ task panicked: {0}")]
+    TaskPanicked(String),
+    #[error("{0}")]
+    Usb(String),
+    #[error("{0}")]
+    Channel(String),
+}
+
+#[derive(Error, Debug)]
 pub enum AppError {
     #[error("BLE error: {0}")]
-    Ble(String),
+    Ble(#[from] BleError),
     #[error("ANT+ error: {0}")]
-    AntPlus(String),
+    AntPlus(#[from] AntError),
     #[error("Device not found: {0}")]
     DeviceNotFound(String),
     #[error("Database error: {0}")]


### PR DESCRIPTION
## Summary
- Add `BleError` sub-enum: `NotInitialized`, `NoAdapter`, `UnrecognizedDevice`, `CharacteristicNotFound`, `Btleplug`
- Add `AntError` sub-enum: `NoUsbStick`, `NoFreeChannel`, `NotSupported`, `TaskPanicked`, `Usb`, `Channel`
- Change `AppError::Ble(String)` to `AppError::Ble(BleError)` and `AppError::AntPlus(String)` to `AppError::AntPlus(AntError)` using `#[from]`
- Update ~40 call sites across 6 files
- Frontend serialization unchanged (`{ code: "ble_error", message: "..." }`)

## Test plan
- [ ] `cargo test` — all 263 tests pass
- [ ] `cargo check --features production` — compiles clean

Closes #138