### PR TITLE
Add missing migration 007 for zone_config column

### DIFF
--- a/src-tauri/src/session/storage/mod.rs
+++ b/src-tauri/src/session/storage/mod.rs
@@ -90,6 +90,12 @@ impl Storage {
         for stmt in migration_006_stmts {
             run_alter_ignore_duplicate(&pool, stmt).await?;
         }
+        // Migration 007: zone ride config snapshot per session
+        run_alter_ignore_duplicate(
+            &pool,
+            "ALTER TABLE sessions ADD COLUMN zone_config TEXT",
+        )
+        .await?;
         // Migration 008: work (kJ) and variability index
         let migration_008_stmts = [
             "ALTER TABLE sessions ADD COLUMN work_kj REAL",
@@ -772,6 +778,25 @@ mod tests {
 
         let new_dev = devices.iter().find(|d| d.id == "ble-new").unwrap();
         assert_eq!(new_dev.name, Some("HRM".to_string()));
+    }
+
+    #[tokio::test]
+    async fn save_and_get_zone_config() {
+        let (storage, _tmp) = test_storage().await;
+        let summary = make_summary("zc-1");
+        storage.save_session(&summary, b"raw").await.unwrap();
+
+        // No zone config initially
+        let config = storage.get_zone_config("zc-1").await.unwrap();
+        assert_eq!(config, None);
+
+        // Save zone config
+        let zone_json = r#"{"mode":"zone","zone":3}"#;
+        storage.save_zone_config("zc-1", zone_json).await.unwrap();
+
+        // Read it back
+        let config = storage.get_zone_config("zc-1").await.unwrap();
+        assert_eq!(config, Some(zone_json.to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #162

## Summary
- Add the missing migration 007 block to the inline migration runner in `storage/mod.rs` — `ALTER TABLE sessions ADD COLUMN zone_config TEXT`
- The `.sql` file existed on disk (`migrations/007_zone_config.sql`) but the corresponding Rust block was never added, so the column was never created
- `save_zone_config` and `get_zone_config` failed silently on every call (errors swallowed by bare `catch {}` in frontend)
- Add round-trip test: write zone config, read it back, verify NULL for sessions without one

## Test plan
- [x] `cargo test --lib session::storage` — 30/30 pass including new `save_and_get_zone_config`
- [ ] Start a zone ride session, stop it, verify zone config persists in session detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)