### PR TITLE
Replace bare .unwrap() with proper error propagation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -231,7 +231,10 @@ pub async fn set_primary_device(
     device_id: String,
 ) -> Result<(), AppError> {
     info!("Set primary device: {:?} = {}", device_type, device_id);
-    let mut primaries = state.primary_devices.write().unwrap();
+    let mut primaries = state
+        .primary_devices
+        .write()
+        .map_err(|e| AppError::Session(format!("Lock poisoned: {e}")))?;
     primaries.insert(device_type, device_id);
     Ok(())
 }
@@ -240,7 +243,10 @@ pub async fn set_primary_device(
 pub async fn get_primary_devices(
     state: State<'_, AppState>,
 ) -> Result<HashMap<String, String>, AppError> {
-    let primaries = state.primary_devices.read().unwrap();
+    let primaries = state
+        .primary_devices
+        .read()
+        .map_err(|e| AppError::Session(format!("Lock poisoned: {e}")))?;
     Ok(format_primaries(&primaries))
 }
 

--- a/src-tauri/src/device/manager.rs
+++ b/src-tauri/src/device/manager.rs
@@ -331,7 +331,7 @@ impl DeviceManager {
                 Err(e) => return Err(BleError::Btleplug(format!("BLE init failed: {}", e)).into()),
             }
         }
-        let ble = self.ble.as_ref().unwrap();
+        let ble = self.ble.as_ref().ok_or(BleError::NotInitialized)?;
         let mut info = ble.connect_device(device_id).await?;
 
         // Read DIS metadata to populate manufacturer/model/serial


### PR DESCRIPTION
## Summary
- **commands.rs**: `primary_devices` RwLock `.unwrap()` → `.map_err()` returning `AppError::Session` on poisoned lock (#163)
- **manager.rs**: `connect_ble` Option `.unwrap()` → `.ok_or(BleError::NotInitialized)` after BLE init check (#164)

Closes #163, closes #164

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo test` — all 264 tests pass