### PR TITLE
Fix auto-session / manual-session start race condition

### DIFF
--- a/src/lib/stores/autoSession.ts
+++ b/src/lib/stores/autoSession.ts
@@ -1,7 +1,6 @@
 import { writable, get } from 'svelte/store';
 import { currentCadence, currentSpeed, liveMetrics } from '$lib/stores/sensor';
-import { sessionActive, sessionId, sessionPaused } from '$lib/stores/session';
-import { api } from '$lib/tauri';
+import { sessionActive, requestStart, requestStop } from '$lib/stores/session';
 
 export const autoSessionEnabled = writable(false);
 export const autoSessionCountdown = writable<number | null>(null);
@@ -12,8 +11,6 @@ const AUTO_STOP_THRESHOLD_SECS = 3;
 let tickInterval: ReturnType<typeof setInterval> | null = null;
 let cadenceAboveZeroTicks = 0;
 let speedZeroTicks = 0;
-let starting = false;
-let stopping = false;
 
 function tick() {
   const enabled = get(autoSessionEnabled);
@@ -36,7 +33,7 @@ function tick() {
       } else {
         autoSessionCountdown.set(null);
         cadenceAboveZeroTicks = 0;
-        startSession();
+        requestStart().catch(() => {});
       }
     } else {
       cadenceAboveZeroTicks = 0;
@@ -52,7 +49,7 @@ function tick() {
       speedZeroTicks++;
       if (speedZeroTicks >= AUTO_STOP_THRESHOLD_SECS) {
         speedZeroTicks = 0;
-        stopSession();
+        requestStop().catch(() => {});
       }
     } else {
       speedZeroTicks = 0;
@@ -60,36 +57,6 @@ function tick() {
     // Reset start counter when session is active
     cadenceAboveZeroTicks = 0;
     autoSessionCountdown.set(null);
-  }
-}
-
-async function startSession() {
-  if (starting) return;
-  starting = true;
-  try {
-    const id = await api.startSession();
-    sessionId.set(id);
-    sessionActive.set(true);
-    sessionPaused.set(false);
-  } catch {
-    // Ignore — user can still start manually
-  } finally {
-    starting = false;
-  }
-}
-
-async function stopSession() {
-  if (stopping) return;
-  stopping = true;
-  try {
-    await api.stopSession();
-    sessionActive.set(false);
-    sessionId.set(null);
-    sessionPaused.set(false);
-  } catch {
-    // Ignore — user can still stop manually
-  } finally {
-    stopping = false;
   }
 }
 
@@ -110,6 +77,4 @@ export function destroyAutoSession() {
     tickInterval = null;
   }
   resetCounters();
-  starting = false;
-  stopping = false;
 }

--- a/src/lib/stores/session.ts
+++ b/src/lib/stores/session.ts
@@ -1,6 +1,60 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
+import { api, type SessionSummary } from '$lib/tauri';
 
 export const sessionActive = writable(false);
 export const sessionId = writable<string | null>(null);
 export const sessionPaused = writable(false);
 export const dashboardView = writable<'gauges' | 'graphs' | 'retro'>('gauges');
+
+/** In-flight start promise — ensures only one start request at a time. */
+let startInflight: Promise<string> | null = null;
+
+/** In-flight stop promise — ensures only one stop request at a time. */
+let stopInflight: Promise<SessionSummary | null> | null = null;
+
+/**
+ * Request a session start. If a start is already in-flight, piggybacks on
+ * that request. If a session is already active, returns the existing ID.
+ * Updates sessionActive/sessionId/sessionPaused atomically on success.
+ */
+export async function requestStart(): Promise<string> {
+  const id = get(sessionId);
+  if (get(sessionActive) && id) return id;
+
+  if (startInflight) return startInflight;
+
+  const promise = api.startSession();
+  startInflight = promise;
+  try {
+    const newId = await promise;
+    sessionId.set(newId);
+    sessionActive.set(true);
+    sessionPaused.set(false);
+    return newId;
+  } finally {
+    startInflight = null;
+  }
+}
+
+/**
+ * Request a session stop. If a stop is already in-flight, piggybacks on
+ * that request. If no session is active, returns null.
+ * Updates sessionActive/sessionId/sessionPaused atomically on success.
+ */
+export async function requestStop(): Promise<SessionSummary | null> {
+  if (!get(sessionActive)) return null;
+
+  if (stopInflight) return stopInflight;
+
+  const promise = api.stopSession();
+  stopInflight = promise;
+  try {
+    const result = await promise;
+    sessionActive.set(false);
+    sessionId.set(null);
+    sessionPaused.set(false);
+    return result ?? null;
+  } finally {
+    stopInflight = null;
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import ZoneRideStatus from '$lib/components/ZoneRideStatus.svelte';
   import ConnectionHealth from '$lib/components/ConnectionHealth.svelte';
   import { currentPower, currentHR, currentCadence, currentSpeed, liveMetrics } from '$lib/stores/sensor';
-  import { sessionActive, sessionPaused, sessionId, dashboardView } from '$lib/stores/session';
+  import { sessionActive, sessionPaused, sessionId, dashboardView, requestStart, requestStop } from '$lib/stores/session';
   import { autoSessionEnabled, autoSessionCountdown } from '$lib/stores/autoSession';
   import { trainerConnected } from '$lib/stores/devices';
   import { unitSystem, formatSpeed, speedUnit } from '$lib/stores/units';
@@ -45,10 +45,7 @@
           try { await stopZoneRide(); } catch { /* best-effort */ }
         }
         const currentSessionId = $sessionId;
-        const result = await api.stopSession();
-        sessionActive.set(false);
-        sessionId.set(null);
-        sessionPaused.set(false);
+        const result = await requestStop();
         showZoneBuilder = false;
         stopZonePolling();
 
@@ -73,10 +70,7 @@
           postRideSession = result;
         }
       } else {
-        const id = await api.startSession();
-        sessionId.set(id);
-        sessionActive.set(true);
-        sessionPaused.set(false);
+        await requestStart();
       }
     } catch (e) {
       error = extractError(e);


### PR DESCRIPTION
## Summary
- Centralize session start/stop into `requestStart()` / `requestStop()` in `session.ts` with **in-flight promise deduplication** — if two callers trigger simultaneously, the second piggybacks on the first's promise
- Auto-session and manual Start button both go through these shared functions, eliminating the race
- Removed redundant `starting`/`stopping` boolean flags from `autoSession.ts`
- Store updates (`sessionActive`, `sessionId`, `sessionPaused`) happen atomically in one place

Closes #165

## Test plan
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `cargo test` — all 264 tests pass
- [ ] Manual: enable auto-session, let countdown trigger while clicking Start — only one session should be created, no error banner