### PR TITLE
Check rows_affected in save_zone_config to detect missing sessions

### DIFF
--- a/src-tauri/src/session/storage/mod.rs
+++ b/src-tauri/src/session/storage/mod.rs
@@ -800,6 +800,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn save_zone_config_nonexistent_session_returns_error() {
+        let (storage, _tmp) = test_storage().await;
+        let result = storage.save_zone_config("no-such-id", r#"{"zone":1}"#).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Session not found"),
+            "expected 'Session not found', got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
     async fn list_devices_ordered_by_last_seen() {
         let (storage, _tmp) = test_storage().await;
         let d1 = make_device("d1", Some("Oldest"), "2024-01-01T00:00:00Z");

--- a/src-tauri/src/session/storage/sessions.rs
+++ b/src-tauri/src/session/storage/sessions.rs
@@ -303,12 +303,15 @@ impl Storage {
         session_id: &str,
         zone_config: &str,
     ) -> Result<(), AppError> {
-        sqlx::query("UPDATE sessions SET zone_config = ? WHERE id = ?")
+        let result = sqlx::query("UPDATE sessions SET zone_config = ? WHERE id = ?")
             .bind(zone_config)
             .bind(session_id)
             .execute(&self.pool)
             .await
             .map_err(AppError::Database)?;
+        if result.rows_affected() == 0 {
+            return Err(AppError::Session(format!("Session not found: {}", session_id)));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- `save_zone_config` now checks `rows_affected() == 0` and returns `AppError::Session("Session not found: ...")` instead of silently succeeding when the session ID doesn't exist
- Matches the existing `update_session_metadata` pattern
- Added test: `save_zone_config_nonexistent_session_returns_error`

Closes #166

## Test plan
- [x] `cargo test` — 265 tests pass (264 existing + 1 new)
- [x] Existing `save_and_get_zone_config` test still passes (happy path unchanged)